### PR TITLE
This commit performs the initial merge of the KPhysics library into t…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ target/
 build/
 .gradle/
 
+
+KPhysics/

--- a/jbox2d-testbed-jogl/build.gradle.kts
+++ b/jbox2d-testbed-jogl/build.gradle.kts
@@ -10,7 +10,7 @@ application {
 }
 
 dependencies {
-    implementation(project(":kbox2d-library"))
+    implementation(project(":kfizzix-library"))
     implementation("de.pirckheimer-gymnasium:jbox2d-serialization:3.1.0")
     implementation("de.pirckheimer-gymnasium:jbox2d-testbed:3.1.0")
     implementation("org.jogamp.gluegen:gluegen-rt-main:2.1.2")

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/jbox2d/common/Mat22.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/jbox2d/common/Mat22.kt
@@ -21,7 +21,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.jbox2d.common
+package com.github.hereliesaz.kfizzix.common
 
 import java.io.Serializable
 

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/jbox2d/common/Mat33.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/jbox2d/common/Mat33.kt
@@ -21,7 +21,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.jbox2d.common
+package com.github.hereliesaz.kfizzix.common
 
 import java.io.Serializable
 

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/jbox2d/common/MathUtils.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/jbox2d/common/MathUtils.kt
@@ -43,7 +43,7 @@
  * misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  */
-package com.hereliesaz.jbox2d.common
+package com.github.hereliesaz.kfizzix.common
 
 import java.util.Random
 

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/jbox2d/common/Rot.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/jbox2d/common/Rot.kt
@@ -21,7 +21,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.jbox2d.common
+package com.github.hereliesaz.kfizzix.common
 
 import java.io.Serializable
 

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/jbox2d/common/Settings.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/jbox2d/common/Settings.kt
@@ -21,7 +21,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.jbox2d.common
+package com.github.hereliesaz.kfizzix.common
 
 /**
  * Global tuning constants based on MKS units and various integer maximums

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/jbox2d/common/Sweep.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/jbox2d/common/Sweep.kt
@@ -21,7 +21,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.jbox2d.common
+package com.github.hereliesaz.kfizzix.common
 
 import java.io.Serializable
 

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/jbox2d/common/Transform.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/jbox2d/common/Transform.kt
@@ -21,7 +21,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.jbox2d.common
+package com.github.hereliesaz.kfizzix.common
 
 import java.io.Serializable
 

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/jbox2d/common/Vec2.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/jbox2d/common/Vec2.kt
@@ -21,7 +21,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.jbox2d.common
+package com.github.hereliesaz.kfizzix.common
 
 import java.io.Serializable
 

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/jbox2d/common/Vec3.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/jbox2d/common/Vec3.kt
@@ -21,7 +21,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.jbox2d.common
+package com.github.hereliesaz.kfizzix.common
 
 import java.io.Serializable
 

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/callbacks/ContactFilter.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/callbacks/ContactFilter.kt
@@ -21,10 +21,10 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.callbacks
+package com.github.hereliesaz.kfizzix.callbacks
 
-import com.hereliesaz.kbox2d.dynamics.Filter
-import com.hereliesaz.kbox2d.dynamics.Fixture
+import com.github.hereliesaz.kfizzix.dynamics.Filter
+import com.github.hereliesaz.kfizzix.dynamics.Fixture
 
 /**
  * Implement this class to provide collision filtering. In other words, you can

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/callbacks/ContactImpulse.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/callbacks/ContactImpulse.kt
@@ -21,9 +21,9 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.callbacks
+package com.github.hereliesaz.kfizzix.callbacks
 
-import com.hereliesaz.kbox2d.common.Settings
+import com.github.hereliesaz.kfizzix.common.Settings
 
 /**
  * Contact impulses for reporting. Impulses are used instead of forces because

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/callbacks/ContactListener.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/callbacks/ContactListener.kt
@@ -21,10 +21,10 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.callbacks
+package com.github.hereliesaz.kfizzix.callbacks
 
-import com.hereliesaz.kbox2d.collision.Manifold
-import com.hereliesaz.kbox2d.dynamics.contacts.Contact
+import com.github.hereliesaz.kfizzix.collision.Manifold
+import com.github.hereliesaz.kfizzix.dynamics.contacts.Contact
 
 /**
  * Implement this class to get contact information. You can use these results

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/callbacks/DebugDraw.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/callbacks/DebugDraw.kt
@@ -21,13 +21,13 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.callbacks
+package com.github.hereliesaz.kfizzix.callbacks
 
-import com.hereliesaz.kbox2d.common.Color3f
-import com.hereliesaz.kbox2d.common.IViewportTransform
-import com.hereliesaz.kbox2d.common.Transform
-import com.hereliesaz.kbox2d.common.Vec2
-import com.hereliesaz.kbox2d.particle.ParticleColor
+import com.github.hereliesaz.kfizzix.common.Color3f
+import com.github.hereliesaz.kfizzix.common.IViewportTransform
+import com.github.hereliesaz.kfizzix.common.Transform
+import com.github.hereliesaz.kfizzix.common.Vec2
+import com.github.hereliesaz.kfizzix.particle.ParticleColor
 
 /**
  * Implement this abstract class to allow JBox2d to automatically draw your

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/callbacks/DestructionListener.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/callbacks/DestructionListener.kt
@@ -21,10 +21,10 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.callbacks
+package com.github.hereliesaz.kfizzix.callbacks
 
-import com.hereliesaz.kbox2d.dynamics.Fixture
-import com.hereliesaz.kbox2d.dynamics.joints.Joint
+import com.github.hereliesaz.kfizzix.dynamics.Fixture
+import com.github.hereliesaz.kfizzix.dynamics.joints.Joint
 
 /**
  * Joints and fixtures are destroyed when their associated body is destroyed.

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/callbacks/PairCallback.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/callbacks/PairCallback.kt
@@ -21,7 +21,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.callbacks
+package com.github.hereliesaz.kfizzix.callbacks
 
 /**
  * @author Daniel Murphy

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/callbacks/ParticleDestructionListener.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/callbacks/ParticleDestructionListener.kt
@@ -21,10 +21,10 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.callbacks
+package com.github.hereliesaz.kfizzix.callbacks
 
-import com.hereliesaz.kbox2d.dynamics.World
-import com.hereliesaz.kbox2d.particle.ParticleGroup
+import com.github.hereliesaz.kfizzix.dynamics.World
+import com.github.hereliesaz.kfizzix.particle.ParticleGroup
 
 /**
  * @author Daniel Murphy

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/callbacks/ParticleQueryCallback.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/callbacks/ParticleQueryCallback.kt
@@ -21,9 +21,9 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.callbacks
+package com.github.hereliesaz.kfizzix.callbacks
 
-import com.hereliesaz.kbox2d.dynamics.World
+import com.github.hereliesaz.kfizzix.dynamics.World
 
 /**
  * Callback class for AABB queries. See

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/callbacks/ParticleRaycastCallback.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/callbacks/ParticleRaycastCallback.kt
@@ -21,9 +21,9 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.callbacks
+package com.github.hereliesaz.kfizzix.callbacks
 
-import com.hereliesaz.kbox2d.common.Vec2
+import com.github.hereliesaz.kfizzix.common.Vec2
 
 /**
  * @author Daniel Murphy

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/callbacks/QueryCallback.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/callbacks/QueryCallback.kt
@@ -21,10 +21,10 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.callbacks
+package com.github.hereliesaz.kfizzix.callbacks
 
-import com.hereliesaz.kbox2d.dynamics.Fixture
-import com.hereliesaz.kbox2d.dynamics.World
+import com.github.hereliesaz.kfizzix.dynamics.Fixture
+import com.github.hereliesaz.kfizzix.dynamics.World
 
 /**
  * Callback class for AABB queries. See

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/callbacks/RayCastCallback.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/callbacks/RayCastCallback.kt
@@ -21,11 +21,11 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.callbacks
+package com.github.hereliesaz.kfizzix.callbacks
 
-import com.hereliesaz.kbox2d.common.Vec2
-import com.hereliesaz.kbox2d.dynamics.Fixture
-import com.hereliesaz.kbox2d.dynamics.World
+import com.github.hereliesaz.kfizzix.common.Vec2
+import com.github.hereliesaz.kfizzix.dynamics.Fixture
+import com.github.hereliesaz.kfizzix.dynamics.World
 
 /**
  * Callback class for ray casts. See

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/callbacks/TreeCallback.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/callbacks/TreeCallback.kt
@@ -21,9 +21,9 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.callbacks
+package com.github.hereliesaz.kfizzix.callbacks
 
-import com.hereliesaz.kbox2d.collision.broadphase.DynamicTree
+import com.github.hereliesaz.kfizzix.collision.broadphase.DynamicTree
 
 /**
  * callback for [DynamicTree]

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/callbacks/TreeRayCastCallback.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/callbacks/TreeRayCastCallback.kt
@@ -21,10 +21,10 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.callbacks
+package com.github.hereliesaz.kfizzix.callbacks
 
-import com.hereliesaz.kbox2d.collision.RayCastInput
-import com.hereliesaz.kbox2d.collision.broadphase.DynamicTree
+import com.github.hereliesaz.kfizzix.collision.RayCastInput
+import com.github.hereliesaz.kfizzix.collision.broadphase.DynamicTree
 
 /**
  * callback for [DynamicTree]

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/AABB.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/AABB.kt
@@ -21,13 +21,13 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.collision
+package com.github.hereliesaz.kfizzix.collision
 
-import com.hereliesaz.kbox2d.common.MathUtils
-import com.hereliesaz.kbox2d.common.Settings
-import com.hereliesaz.kbox2d.common.Vec2
-import com.hereliesaz.kbox2d.pooling.WorldPool
-import com.hereliesaz.kbox2d.pooling.normal.DefaultWorldPool
+import com.github.hereliesaz.kfizzix.common.MathUtils
+import com.github.hereliesaz.kfizzix.common.Settings
+import com.github.hereliesaz.kfizzix.common.Vec2
+import com.github.hereliesaz.kfizzix.pooling.WorldPool
+import com.github.hereliesaz.kfizzix.pooling.normal.DefaultWorldPool
 
 /**
  * An axis-aligned bounding box.

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/Collision.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/Collision.kt
@@ -21,20 +21,20 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.collision
+package com.github.hereliesaz.kfizzix.collision
 
-import com.hereliesaz.kbox2d.collision.Distance.SimplexCache
-import com.hereliesaz.kbox2d.collision.Manifold.ManifoldType
-import com.hereliesaz.kbox2d.collision.shapes.CircleShape
-import com.hereliesaz.kbox2d.collision.shapes.EdgeShape
-import com.hereliesaz.kbox2d.collision.shapes.PolygonShape
-import com.hereliesaz.kbox2d.collision.shapes.Shape
-import com.hereliesaz.kbox2d.common.MathUtils
-import com.hereliesaz.kbox2d.common.Rot
-import com.hereliesaz.kbox2d.common.Settings
-import com.hereliesaz.kbox2d.common.Transform
-import com.hereliesaz.kbox2d.common.Vec2
-import com.hereliesaz.kbox2d.pooling.WorldPool
+import com.github.hereliesaz.kfizzix.collision.Distance.SimplexCache
+import com.github.hereliesaz.kfizzix.collision.Manifold.ManifoldType
+import com.github.hereliesaz.kfizzix.collision.shapes.CircleShape
+import com.github.hereliesaz.kfizzix.collision.shapes.EdgeShape
+import com.github.hereliesaz.kfizzix.collision.shapes.PolygonShape
+import com.github.hereliesaz.kfizzix.collision.shapes.Shape
+import com.github.hereliesaz.kfizzix.common.MathUtils
+import com.github.hereliesaz.kfizzix.common.Rot
+import com.github.hereliesaz.kfizzix.common.Settings
+import com.github.hereliesaz.kfizzix.common.Transform
+import com.github.hereliesaz.kfizzix.common.Vec2
+import com.github.hereliesaz.kfizzix.pooling.WorldPool
 
 /**
  * Functions used for computing contact points, distance queries, and TOI

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/ContactID.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/ContactID.kt
@@ -43,7 +43,7 @@
  * misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  */
-package com.hereliesaz.kbox2d.collision
+package com.github.hereliesaz.kfizzix.collision
 
 /**
  * Contact ids to facilitate warm starting. Note: the ContactFeatures class is

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/Distance.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/Distance.kt
@@ -21,18 +21,18 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.collision
+package com.github.hereliesaz.kfizzix.collision
 
-import com.hereliesaz.kbox2d.collision.shapes.ChainShape
-import com.hereliesaz.kbox2d.collision.shapes.CircleShape
-import com.hereliesaz.kbox2d.collision.shapes.EdgeShape
-import com.hereliesaz.kbox2d.collision.shapes.PolygonShape
-import com.hereliesaz.kbox2d.collision.shapes.Shape
-import com.hereliesaz.kbox2d.common.MathUtils
-import com.hereliesaz.kbox2d.common.Rot
-import com.hereliesaz.kbox2d.common.Settings
-import com.hereliesaz.kbox2d.common.Vec2
-import com.hereliesaz.kbox2d.common.Transform
+import com.github.hereliesaz.kfizzix.collision.shapes.ChainShape
+import com.github.hereliesaz.kfizzix.collision.shapes.CircleShape
+import com.github.hereliesaz.kfizzix.collision.shapes.EdgeShape
+import com.github.hereliesaz.kfizzix.collision.shapes.PolygonShape
+import com.github.hereliesaz.kfizzix.collision.shapes.Shape
+import com.github.hereliesaz.kfizzix.common.MathUtils
+import com.github.hereliesaz.kfizzix.common.Rot
+import com.github.hereliesaz.kfizzix.common.Settings
+import com.github.hereliesaz.kfizzix.common.Vec2
+import com.github.hereliesaz.kfizzix.common.Transform
 
 /**
  * This is non-static for faster pooling. To get an instance, use the

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/DistanceInput.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/DistanceInput.kt
@@ -21,10 +21,10 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.collision
+package com.github.hereliesaz.kfizzix.collision
 
-import com.hereliesaz.kbox2d.collision.Distance.DistanceProxy
-import com.hereliesaz.kbox2d.common.Transform
+import com.github.hereliesaz.kfizzix.collision.Distance.DistanceProxy
+import com.github.hereliesaz.kfizzix.common.Transform
 
 /**
  * Input for Distance. You have to option to use the shape radii in the

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/DistanceOutput.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/DistanceOutput.kt
@@ -21,9 +21,9 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.collision
+package com.github.hereliesaz.kfizzix.collision
 
-import com.hereliesaz.kbox2d.common.Vec2
+import com.github.hereliesaz.kfizzix.common.Vec2
 
 /**
  * Output for Distance.

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/Manifold.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/Manifold.kt
@@ -21,10 +21,10 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.collision
+package com.github.hereliesaz.kfizzix.collision
 
-import com.hereliesaz.kbox2d.common.Settings
-import com.hereliesaz.kbox2d.common.Vec2
+import com.github.hereliesaz.kfizzix.common.Settings
+import com.github.hereliesaz.kfizzix.common.Vec2
 
 /**
  * A manifold for two touching convex shapes. Box2D supports multiple types of

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/ManifoldPoint.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/ManifoldPoint.kt
@@ -21,9 +21,9 @@
  * ARISING IN ANY WAY OUT of the use of this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.collision
+package com.github.hereliesaz.kfizzix.collision
 
-import com.hereliesaz.kbox2d.common.Vec2
+import com.github.hereliesaz.kfizzix.common.Vec2
 
 /**
  * A manifold point is a contact point belonging to a contact manifold. It holds

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/RayCastInput.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/RayCastInput.kt
@@ -21,9 +21,9 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.collision
+package com.github.hereliesaz.kfizzix.collision
 
-import com.hereliesaz.kbox2d.common.Vec2
+import com.github.hereliesaz.kfizzix.common.Vec2
 
 /**
  * Ray-cast input data. The ray extends from p1 to p1 + maxFraction * (p2 - p1).

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/RayCastOutput.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/RayCastOutput.kt
@@ -21,9 +21,9 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.collision
+package com.github.hereliesaz.kfizzix.collision
 
-import com.hereliesaz.kbox2d.common.Vec2
+import com.github.hereliesaz.kfizzix.common.Vec2
 
 /**
  * Ray-cast output data. The ray hits at p1 + fraction * (p2 - p1), where p1 and

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/TimeOfImpact.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/TimeOfImpact.kt
@@ -21,17 +21,17 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.collision
+package com.github.hereliesaz.kfizzix.collision
 
-import com.hereliesaz.kbox2d.collision.Distance.DistanceProxy
-import com.hereliesaz.kbox2d.collision.Distance.SimplexCache
-import com.hereliesaz.kbox2d.common.MathUtils
-import com.hereliesaz.kbox2d.common.Rot
-import com.hereliesaz.kbox2d.common.Settings
-import com.hereliesaz.kbox2d.common.Sweep
-import com.hereliesaz.kbox2d.common.Transform
-import com.hereliesaz.kbox2d.common.Vec2
-import com.hereliesaz.kbox2d.pooling.WorldPool
+import com.github.hereliesaz.kfizzix.collision.Distance.DistanceProxy
+import com.github.hereliesaz.kfizzix.collision.Distance.SimplexCache
+import com.github.hereliesaz.kfizzix.common.MathUtils
+import com.github.hereliesaz.kfizzix.common.Rot
+import com.github.hereliesaz.kfizzix.common.Settings
+import com.github.hereliesaz.kfizzix.common.Sweep
+import com.github.hereliesaz.kfizzix.common.Transform
+import com.github.hereliesaz.kfizzix.common.Vec2
+import com.github.hereliesaz.kfizzix.pooling.WorldPool
 
 /**
  * Class used for computing the time of impact. This class should not be

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/WorldManifold.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/WorldManifold.kt
@@ -21,13 +21,13 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.collision
+package com.github.hereliesaz.kfizzix.collision
 
-import com.hereliesaz.kbox2d.common.MathUtils
-import com.hereliesaz.kbox2d.common.Rot
-import com.hereliesaz.kbox2d.common.Settings
-import com.hereliesaz.kbox2d.common.Transform
-import com.hereliesaz.kbox2d.common.Vec2
+import com.github.hereliesaz.kfizzix.common.MathUtils
+import com.github.hereliesaz.kfizzix.common.Rot
+import com.github.hereliesaz.kfizzix.common.Settings
+import com.github.hereliesaz.kfizzix.common.Transform
+import com.github.hereliesaz.kfizzix.common.Vec2
 
 /**
  * This is used to compute the current state of a contact manifold.

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/broadphase/BroadPhase.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/broadphase/BroadPhase.kt
@@ -21,15 +21,15 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.collision.broadphase
+package com.github.hereliesaz.kfizzix.collision.broadphase
 
-import com.hereliesaz.kbox2d.callbacks.DebugDraw
-import com.hereliesaz.kbox2d.callbacks.PairCallback
-import com.hereliesaz.kbox2d.callbacks.TreeCallback
-import com.hereliesaz.kbox2d.callbacks.TreeRayCastCallback
-import com.hereliesaz.kbox2d.collision.AABB
-import com.hereliesaz.kbox2d.collision.RayCastInput
-import com.hereliesaz.kbox2d.common.Vec2
+import com.github.hereliesaz.kfizzix.callbacks.DebugDraw
+import com.github.hereliesaz.kfizzix.callbacks.PairCallback
+import com.github.hereliesaz.kfizzix.callbacks.TreeCallback
+import com.github.hereliesaz.kfizzix.callbacks.TreeRayCastCallback
+import com.github.hereliesaz.kfizzix.collision.AABB
+import com.github.hereliesaz.kfizzix.collision.RayCastInput
+import com.github.hereliesaz.kfizzix.common.Vec2
 
 /**
  * The broad-phase is used for computing pairs and performing volume queries and

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/broadphase/BroadPhaseStrategy.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/broadphase/BroadPhaseStrategy.kt
@@ -21,14 +21,14 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.collision.broadphase
+package com.github.hereliesaz.kfizzix.collision.broadphase
 
-import com.hereliesaz.kbox2d.callbacks.DebugDraw
-import com.hereliesaz.kbox2d.callbacks.TreeCallback
-import com.hereliesaz.kbox2d.callbacks.TreeRayCastCallback
-import com.hereliesaz.kbox2d.collision.AABB
-import com.hereliesaz.kbox2d.collision.RayCastInput
-import com.hereliesaz.kbox2d.common.Vec2
+import com.github.hereliesaz.kfizzix.callbacks.DebugDraw
+import com.github.hereliesaz.kfizzix.callbacks.TreeCallback
+import com.github.hereliesaz.kfizzix.callbacks.TreeRayCastCallback
+import com.github.hereliesaz.kfizzix.collision.AABB
+import com.github.hereliesaz.kfizzix.collision.RayCastInput
+import com.github.hereliesaz.kfizzix.common.Vec2
 
 /**
  * @author Daniel Murphy

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/broadphase/DefaultBroadPhaseBuffer.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/broadphase/DefaultBroadPhaseBuffer.kt
@@ -21,15 +21,15 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.collision.broadphase
+package com.github.hereliesaz.kfizzix.collision.broadphase
 
-import com.hereliesaz.kbox2d.callbacks.DebugDraw
-import com.hereliesaz.kbox2d.callbacks.PairCallback
-import com.hereliesaz.kbox2d.callbacks.TreeCallback
-import com.hereliesaz.kbox2d.callbacks.TreeRayCastCallback
-import com.hereliesaz.kbox2d.collision.AABB
-import com.hereliesaz.kbox2d.collision.RayCastInput
-import com.hereliesaz.kbox2d.common.Vec2
+import com.github.hereliesaz.kfizzix.callbacks.DebugDraw
+import com.github.hereliesaz.kfizzix.callbacks.PairCallback
+import com.github.hereliesaz.kfizzix.callbacks.TreeCallback
+import com.github.hereliesaz.kfizzix.callbacks.TreeRayCastCallback
+import com.github.hereliesaz.kfizzix.collision.AABB
+import com.github.hereliesaz.kfizzix.collision.RayCastInput
+import com.github.hereliesaz.kfizzix.common.Vec2
 import java.util.*
 
 /**

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/broadphase/DynamicTree.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/broadphase/DynamicTree.kt
@@ -21,17 +21,17 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.collision.broadphase
+package com.github.hereliesaz.kfizzix.collision.broadphase
 
-import com.hereliesaz.kbox2d.callbacks.DebugDraw
-import com.hereliesaz.kbox2d.callbacks.TreeCallback
-import com.hereliesaz.kbox2d.callbacks.TreeRayCastCallback
-import com.hereliesaz.kbox2d.collision.AABB
-import com.hereliesaz.kbox2d.collision.RayCastInput
-import com.hereliesaz.kbox2d.common.Color3f
-import com.hereliesaz.kbox2d.common.MathUtils
-import com.hereliesaz.kbox2d.common.Settings
-import com.hereliesaz.kbox2d.common.Vec2
+import com.github.hereliesaz.kfizzix.callbacks.DebugDraw
+import com.github.hereliesaz.kfizzix.callbacks.TreeCallback
+import com.github.hereliesaz.kfizzix.callbacks.TreeRayCastCallback
+import com.github.hereliesaz.kfizzix.collision.AABB
+import com.github.hereliesaz.kfizzix.collision.RayCastInput
+import com.github.hereliesaz.kfizzix.common.Color3f
+import com.github.hereliesaz.kfizzix.common.MathUtils
+import com.github.hereliesaz.kfizzix.common.Settings
+import com.github.hereliesaz.kfizzix.common.Vec2
 
 /**
  * A dynamic tree arranges data in a binary tree to accelerate queries such as

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/broadphase/DynamicTreeFlatNodes.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/broadphase/DynamicTreeFlatNodes.kt
@@ -21,18 +21,18 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.collision.broadphase
+package com.github.hereliesaz.kfizzix.collision.broadphase
 
-import com.hereliesaz.kbox2d.callbacks.DebugDraw
-import com.hereliesaz.kbox2d.callbacks.TreeCallback
-import com.hereliesaz.kbox2d.callbacks.TreeRayCastCallback
-import com.hereliesaz.kbox2d.collision.AABB
-import com.hereliesaz.kbox2d.collision.RayCastInput
-import com.hereliesaz.kbox2d.common.BufferUtils
-import com.hereliesaz.kbox2d.common.Color3f
-import com.hereliesaz.kbox2d.common.MathUtils
-import com.hereliesaz.kbox2d.common.Settings
-import com.hereliesaz.kbox2d.common.Vec2
+import com.github.hereliesaz.kfizzix.callbacks.DebugDraw
+import com.github.hereliesaz.kfizzix.callbacks.TreeCallback
+import com.github.hereliesaz.kfizzix.callbacks.TreeRayCastCallback
+import com.github.hereliesaz.kfizzix.collision.AABB
+import com.github.hereliesaz.kfizzix.collision.RayCastInput
+import com.github.hereliesaz.kfizzix.common.BufferUtils
+import com.github.hereliesaz.kfizzix.common.Color3f
+import com.github.hereliesaz.kfizzix.common.MathUtils
+import com.github.hereliesaz.kfizzix.common.Settings
+import com.github.hereliesaz.kfizzix.common.Vec2
 
 /**
  * @author Daniel Murphy

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/broadphase/DynamicTreeNode.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/broadphase/DynamicTreeNode.kt
@@ -21,9 +21,9 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.collision.broadphase
+package com.github.hereliesaz.kfizzix.collision.broadphase
 
-import com.hereliesaz.kbox2d.collision.AABB
+import com.github.hereliesaz.kfizzix.collision.AABB
 
 /**
  * @author Daniel Murphy

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/shapes/ChainShape.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/shapes/ChainShape.kt
@@ -21,16 +21,16 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.collision.shapes
+package com.github.hereliesaz.kfizzix.collision.shapes
 
-import com.hereliesaz.kbox2d.collision.AABB
-import com.hereliesaz.kbox2d.collision.RayCastInput
-import com.hereliesaz.kbox2d.collision.RayCastOutput
-import com.hereliesaz.kbox2d.common.MathUtils
-import com.hereliesaz.kbox2d.common.Rot
-import com.hereliesaz.kbox2d.common.Settings
-import com.hereliesaz.kbox2d.common.Transform
-import com.hereliesaz.kbox2d.common.Vec2
+import com.github.hereliesaz.kfizzix.collision.AABB
+import com.github.hereliesaz.kfizzix.collision.RayCastInput
+import com.github.hereliesaz.kfizzix.collision.RayCastOutput
+import com.github.hereliesaz.kfizzix.common.MathUtils
+import com.github.hereliesaz.kfizzix.common.Rot
+import com.github.hereliesaz.kfizzix.common.Settings
+import com.github.hereliesaz.kfizzix.common.Transform
+import com.github.hereliesaz.kfizzix.common.Vec2
 
 /**
  * A chain shape is a free form sequence of line segments. The chain has

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/shapes/CircleShape.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/shapes/CircleShape.kt
@@ -21,16 +21,16 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.collision.shapes
+package com.github.hereliesaz.kfizzix.collision.shapes
 
-import com.hereliesaz.kbox2d.collision.AABB
-import com.hereliesaz.kbox2d.collision.RayCastInput
-import com.hereliesaz.kbox2d.collision.RayCastOutput
-import com.hereliesaz.kbox2d.common.MathUtils
-import com.hereliesaz.kbox2d.common.Rot
-import com.hereliesaz.kbox2d.common.Settings
-import com.hereliesaz.kbox2d.common.Transform
-import com.hereliesaz.kbox2d.common.Vec2
+import com.github.hereliesaz.kfizzix.collision.AABB
+import com.github.hereliesaz.kfizzix.collision.RayCastInput
+import com.github.hereliesaz.kfizzix.collision.RayCastOutput
+import com.github.hereliesaz.kfizzix.common.MathUtils
+import com.github.hereliesaz.kfizzix.common.Rot
+import com.github.hereliesaz.kfizzix.common.Settings
+import com.github.hereliesaz.kfizzix.common.Transform
+import com.github.hereliesaz.kfizzix.common.Vec2
 
 /**
  * A circle shape.

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/shapes/EdgeShape.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/shapes/EdgeShape.kt
@@ -21,16 +21,16 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.collision.shapes
+package com.github.hereliesaz.kfizzix.collision.shapes
 
-import com.hereliesaz.kbox2d.collision.AABB
-import com.hereliesaz.kbox2d.collision.RayCastInput
-import com.hereliesaz.kbox2d.collision.RayCastOutput
-import com.hereliesaz.kbox2d.common.MathUtils
-import com.hereliesaz.kbox2d.common.Rot
-import com.hereliesaz.kbox2d.common.Settings
-import com.hereliesaz.kbox2d.common.Transform
-import com.hereliesaz.kbox2d.common.Vec2
+import com.github.hereliesaz.kfizzix.collision.AABB
+import com.github.hereliesaz.kfizzix.collision.RayCastInput
+import com.github.hereliesaz.kfizzix.collision.RayCastOutput
+import com.github.hereliesaz.kfizzix.common.MathUtils
+import com.github.hereliesaz.kfizzix.common.Rot
+import com.github.hereliesaz.kfizzix.common.Settings
+import com.github.hereliesaz.kfizzix.common.Transform
+import com.github.hereliesaz.kfizzix.common.Vec2
 
 /**
  * A line segment (edge) shape. These can be connected in chains or loops to

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/shapes/MassData.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/shapes/MassData.kt
@@ -43,9 +43,9 @@
  * misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  */
-package com.hereliesaz.kbox2d.collision.shapes
+package com.github.hereliesaz.kfizzix.collision.shapes
 
-import com.hereliesaz.kbox2d.common.Vec2
+import com.github.hereliesaz.kfizzix.common.Vec2
 
 /**
  * This holds the mass data computed for a shape.

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/shapes/PolygonShape.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/shapes/PolygonShape.kt
@@ -21,18 +21,18 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.collision.shapes
+package com.github.hereliesaz.kfizzix.collision.shapes
 
-import com.hereliesaz.kbox2d.collision.AABB
-import com.hereliesaz.kbox2d.collision.RayCastInput
-import com.hereliesaz.kbox2d.collision.RayCastOutput
-import com.hereliesaz.kbox2d.common.MathUtils
-import com.hereliesaz.kbox2d.common.Rot
-import com.hereliesaz.kbox2d.common.Settings
-import com.hereliesaz.kbox2d.common.Transform
-import com.hereliesaz.kbox2d.common.Vec2
-import com.hereliesaz.kbox2d.pooling.arrays.IntArray
-import com.hereliesaz.kbox2d.pooling.arrays.Vec2Array
+import com.github.hereliesaz.kfizzix.collision.AABB
+import com.github.hereliesaz.kfizzix.collision.RayCastInput
+import com.github.hereliesaz.kfizzix.collision.RayCastOutput
+import com.github.hereliesaz.kfizzix.common.MathUtils
+import com.github.hereliesaz.kfizzix.common.Rot
+import com.github.hereliesaz.kfizzix.common.Settings
+import com.github.hereliesaz.kfizzix.common.Transform
+import com.github.hereliesaz.kfizzix.common.Vec2
+import com.github.hereliesaz.kfizzix.pooling.arrays.IntArray
+import com.github.hereliesaz.kfizzix.pooling.arrays.Vec2Array
 
 /**
  * A convex polygon shape. Polygons have a maximum number of vertices equal to

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/shapes/Shape.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/shapes/Shape.kt
@@ -21,13 +21,13 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.collision.shapes
+package com.github.hereliesaz.kfizzix.collision.shapes
 
-import com.hereliesaz.kbox2d.collision.AABB
-import com.hereliesaz.kbox2d.collision.RayCastInput
-import com.hereliesaz.kbox2d.collision.RayCastOutput
-import com.hereliesaz.kbox2d.common.Transform
-import com.hereliesaz.kbox2d.common.Vec2
+import com.github.hereliesaz.kfizzix.collision.AABB
+import com.github.hereliesaz.kfizzix.collision.RayCastInput
+import com.github.hereliesaz.kfizzix.collision.RayCastOutput
+import com.github.hereliesaz.kfizzix.common.Transform
+import com.github.hereliesaz.kfizzix.common.Vec2
 
 /**
  * A shape is used for collision detection. You can create a shape however you

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/shapes/ShapeType.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/collision/shapes/ShapeType.kt
@@ -21,7 +21,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.collision.shapes
+package com.github.hereliesaz.kfizzix.collision.shapes
 
 /**
  * Types of shapes

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/common/BufferUtils.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/common/BufferUtils.kt
@@ -21,7 +21,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.common
+package com.github.hereliesaz.kfizzix.common
 
 import java.lang.reflect.Array
 

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/common/Color3f.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/common/Color3f.kt
@@ -21,7 +21,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.common
+package com.github.hereliesaz.kfizzix.common
 
 /**
  * Similar to `javax.vecmath.Color3f` holder

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/common/IViewportTransform.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/common/IViewportTransform.kt
@@ -21,7 +21,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.common
+package com.github.hereliesaz.kfizzix.common
 
 /**
  * This is the viewport transform used from drawing. Use yFlip if you are

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/common/Mat22.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/common/Mat22.kt
@@ -21,7 +21,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.common
+package com.github.hereliesaz.kfizzix.common
 
 import java.io.Serializable
 

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/common/Mat33.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/common/Mat33.kt
@@ -21,7 +21,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.common
+package com.github.hereliesaz.kfizzix.common
 
 import java.io.Serializable
 

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/particle/ParticleBodyContact.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/particle/ParticleBodyContact.kt
@@ -21,10 +21,10 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.particle
+package com.github.hereliesaz.kfizzix.particle
 
-import com.hereliesaz.kbox2d.common.Vec2
-import com.hereliesaz.kbox2d.dynamics.Body
+import com.github.hereliesaz.kfizzix.common.Vec2
+import com.github.hereliesaz.kfizzix.dynamics.Body
 
 class ParticleBodyContact {
     /**

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/particle/ParticleColor.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/particle/ParticleColor.kt
@@ -21,9 +21,9 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.particle
+package com.github.hereliesaz.kfizzix.particle
 
-import com.hereliesaz.kbox2d.common.Color3f
+import com.github.hereliesaz.kfizzix.common.Color3f
 
 /**
  * Small color object for each particle

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/particle/ParticleContact.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/particle/ParticleContact.kt
@@ -21,9 +21,9 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.particle
+package com.github.hereliesaz.kfizzix.particle
 
-import com.hereliesaz.kbox2d.common.Vec2
+import com.github.hereliesaz.kfizzix.common.Vec2
 
 class ParticleContact {
     /**

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/particle/ParticleDef.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/particle/ParticleDef.kt
@@ -21,9 +21,9 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.particle
+package com.github.hereliesaz.kfizzix.particle
 
-import com.hereliesaz.kbox2d.common.Vec2
+import com.github.hereliesaz.kfizzix.common.Vec2
 
 class ParticleDef {
     /**

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/particle/ParticleGroup.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/particle/ParticleGroup.kt
@@ -21,10 +21,10 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.particle
+package com.github.hereliesaz.kfizzix.particle
 
-import com.hereliesaz.kbox2d.common.Transform
-import com.hereliesaz.kbox2d.common.Vec2
+import com.github.hereliesaz.kfizzix.common.Transform
+import com.github.hereliesaz.kfizzix.common.Vec2
 
 /**
  * A group of particles

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/particle/ParticleGroupDef.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/particle/ParticleGroupDef.kt
@@ -21,10 +21,10 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.particle
+package com.github.hereliesaz.kfizzix.particle
 
-import com.hereliesaz.kbox2d.collision.shapes.Shape
-import com.hereliesaz.kbox2d.common.Vec2
+import com.github.hereliesaz.kfizzix.collision.shapes.Shape
+import com.github.hereliesaz.kfizzix.common.Vec2
 
 /**
  * A particle group definition holds all the data needed to construct a particle

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/particle/ParticleGroupType.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/particle/ParticleGroupType.kt
@@ -21,7 +21,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.particle
+package com.github.hereliesaz.kfizzix.particle
 
 object ParticleGroupType {
     /**

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/particle/ParticleSystem.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/particle/ParticleSystem.kt
@@ -21,22 +21,22 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.particle
+package com.github.hereliesaz.kfizzix.particle
 
-import com.hereliesaz.kbox2d.callbacks.ParticleDestructionListener
-import com.hereliesaz.kbox2d.callbacks.ParticleQueryCallback
-import com.hereliesaz.kbox2d.callbacks.ParticleRaycastCallback
-import com.hereliesaz.kbox2d.callbacks.QueryCallback
-import com.hereliesaz.kbox2d.collision.AABB
-import com.hereliesaz.kbox2d.collision.RayCastInput
-import com.hereliesaz.kbox2d.collision.RayCastOutput
-import com.hereliesaz.kbox2d.collision.shapes.Shape
-import com.hereliesaz.kbox2d.common.*
-import com.hereliesaz.kbox2d.dynamics.Body
-import com.hereliesaz.kbox2d.dynamics.Fixture
-import com.hereliesaz.kbox2d.dynamics.TimeStep
-import com.hereliesaz.kbox2d.dynamics.World
-import com.hereliesaz.kbox2d.particle.VoronoiDiagram.VoronoiDiagramCallback
+import com.github.hereliesaz.kfizzix.callbacks.ParticleDestructionListener
+import com.github.hereliesaz.kfizzix.callbacks.ParticleQueryCallback
+import com.github.hereliesaz.kfizzix.callbacks.ParticleRaycastCallback
+import com.github.hereliesaz.kfizzix.callbacks.QueryCallback
+import com.github.hereliesaz.kfizzix.collision.AABB
+import com.github.hereliesaz.kfizzix.collision.RayCastInput
+import com.github.hereliesaz.kfizzix.collision.RayCastOutput
+import com.github.hereliesaz.kfizzix.collision.shapes.Shape
+import com.github.hereliesaz.kfizzix.common.*
+import com.github.hereliesaz.kfizzix.dynamics.Body
+import com.github.hereliesaz.kfizzix.dynamics.Fixture
+import com.github.hereliesaz.kfizzix.dynamics.TimeStep
+import com.github.hereliesaz.kfizzix.dynamics.World
+import com.github.hereliesaz.kfizzix.particle.VoronoiDiagram.VoronoiDiagramCallback
 import java.lang.reflect.Array
 import java.util.*
 

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/particle/ParticleType.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/particle/ParticleType.kt
@@ -21,7 +21,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.particle
+package com.github.hereliesaz.kfizzix.particle
 
 /**
  * The particle type. Can be combined with | operator. Zero means liquid.

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/particle/StackQueue.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/particle/StackQueue.kt
@@ -21,7 +21,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.particle
+package com.github.hereliesaz.kfizzix.particle
 
 class StackQueue<T> {
     private var buffer: Array<T?>? = null

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/particle/VoronoiDiagram.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/particle/VoronoiDiagram.kt
@@ -21,11 +21,11 @@
  * ARISING IN ANY WAY OUT OF THE USE OF this SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.hereliesaz.kbox2d.particle
+package com.github.hereliesaz.kfizzix.particle
 
-import com.hereliesaz.kbox2d.common.MathUtils
-import com.hereliesaz.kbox2d.common.Vec2
-import com.hereliesaz.kbox2d.pooling.normal.MutableStack
+import com.github.hereliesaz.kfizzix.common.MathUtils
+import com.github.hereliesaz.kfizzix.common.Vec2
+import com.github.hereliesaz.kfizzix.pooling.normal.MutableStack
 
 /**
  * A field representing the nearest generator from each point.

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/serialization/JbDeserializer.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/serialization/JbDeserializer.kt
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2013, Daniel Murphy
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 	* Redistributions of source code must retain the above copyright notice,
+ * 	  this list of conditions and the following disclaimer.
+ * 	* Redistributions in binary form must reproduce the above copyright notice,
+ * 	  this list of conditions and the following disclaimer in the documentation
+ * 	  and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.github.hereliesaz.kfizzix.serialization
+
+import com.github.hereliesaz.kfizzix.collision.shapes.Shape
+import com.github.hereliesaz.kfizzix.dynamics.Body
+import com.github.hereliesaz.kfizzix.dynamics.Fixture
+import com.github.hereliesaz.kfizzix.dynamics.World
+import com.github.hereliesaz.kfizzix.dynamics.joints.Joint
+import java.io.IOException
+import java.io.InputStream
+
+/**
+ * Deserializer for kbox2d, used to deserialize any aspect of the physics world.
+ *
+ * @author Daniel Murphy
+ */
+interface JbDeserializer {
+    /**
+     * Sets the object listener, which allows the user to process each physics
+     * object with a tag to do any sort of custom logic.
+     *
+     * @param listener the listener to use
+     */
+    fun setObjectListener(listener: ObjectListener)
+
+    /**
+     * Sets a listener for unsupported exceptions. If a listener is provided, the
+     * deserializer will call the listener with the exception instead of throwing it.
+     * This allows the deserialization process to continue even if some objects are not supported.
+     *
+     * @param listener the listener to use
+     */
+    fun setUnsupportedListener(listener: UnsupportedListener)
+
+    /**
+     * Deserializes a [World] from the given [InputStream].
+     *
+     * @param input the input stream to read from
+     * @return the deserialized world
+     * @throws IOException if an I/O error occurs
+     * @throws UnsupportedObjectException if a read physics object is unsupported and no listener is set.
+     * @see [setUnsupportedListener]
+     */
+    @Throws(IOException::class, UnsupportedObjectException::class)
+    fun deserializeWorld(input: InputStream): World
+
+    /**
+     * Deserializes a [Body] from the given [InputStream] and adds it to the given [World].
+     *
+     * @param world the world to add the body to
+     * @param input the input stream to read from
+     * @return the deserialized body
+     * @throws IOException if an I/O error occurs
+     * @throws UnsupportedObjectException if a read physics object is unsupported and no listener is set.
+     * @see [setUnsupportedListener]
+     */
+    @Throws(IOException::class, UnsupportedObjectException::class)
+    fun deserializeBody(world: World, input: InputStream): Body
+
+    /**
+     * Deserializes a [Fixture] from the given [InputStream] and adds it to the given [Body].
+     *
+     * @param body the body to add the fixture to
+     * @param input the input stream to read from
+     * @return the deserialized fixture
+     * @throws IOException if an I/O error occurs
+     * @throws UnsupportedObjectException if a read physics object is unsupported and no listener is set.
+     * @see [setUnsupportedListener]
+     */
+    @Throws(IOException::class, UnsupportedObjectException::class)
+    fun deserializeFixture(body: Body, input: InputStream): Fixture
+
+    /**
+     * Deserializes a [Shape] from the given [InputStream].
+     *
+     * @param input the input stream to read from
+     * @return the deserialized shape
+     * @throws IOException if an I/O error occurs
+     * @throws UnsupportedObjectException if a read physics object is unsupported and no listener is set.
+     * @see [setUnsupportedListener]
+     */
+    @Throws(IOException::class, UnsupportedObjectException::class)
+    fun deserializeShape(input: InputStream): Shape
+
+    /**
+     * Deserializes a [Joint] from the given [InputStream] and adds it to the given [World].
+     *
+     * @param world the world to add the joint to
+     * @param input the input stream to read from
+     * @param bodyMap a map from body indices to bodies
+     * @param jointMap a map from joint indices to joints
+     * @return the deserialized joint
+     * @throws IOException if an I/O error occurs
+     * @throws UnsupportedObjectException if a read physics object is unsupported and no listener is set.
+     * @see [setUnsupportedListener]
+     */
+    @Throws(IOException::class, UnsupportedObjectException::class)
+    fun deserializeJoint(
+        world: World, input: InputStream,
+        bodyMap: Map<Int, Body>, jointMap: Map<Int, Joint>
+    ): Joint
+
+    /**
+     * Called for each physics object with a tag defined.
+     *
+     * @author Daniel Murphy
+     */
+    interface ObjectListener {
+        /**
+         * Called when a world is processed.
+         * @param world the world
+         * @param tag the tag associated with the world, or null if none
+         */
+        fun processWorld(world: World, tag: Long?)
+
+        /**
+         * Called when a body is processed.
+         * @param body the body
+         * @param tag the tag associated with the body, or null if none
+         */
+        fun processBody(body: Body, tag: Long?)
+
+        /**
+         * Called when a fixture is processed.
+         * @param fixture the fixture
+         * @param tag the tag associated with the fixture, or null if none
+         */
+        fun processFixture(fixture: Fixture, tag: Long?)
+
+        /**
+         * Called when a shape is processed.
+         * @param shape the shape
+         * @param tag the tag associated with the shape, or null if none
+         */
+        fun processShape(shape: Shape, tag: Long?)
+
+        /**
+         * Called when a joint is processed.
+         * @param joint the joint
+         * @param tag the tag associated with the joint, or null if none
+         */
+        fun processJoint(joint: Joint, tag: Long?)
+    }
+}

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/serialization/JbSerializer.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/serialization/JbSerializer.kt
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2013, Daniel Murphy
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 	* Redistributions of source code must retain the above copyright notice,
+ * 	  this list of conditions and the following disclaimer.
+ * 	* Redistributions in binary form must reproduce the above copyright notice,
+ * 	  this list of conditions and the following disclaimer in the documentation
+ * 	  and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.github.hereliesaz.kfizzix.serialization
+
+import com.github.hereliesaz.kfizzix.collision.shapes.Shape
+import com.github.hereliesaz.kfizzix.dynamics.Body
+import com.github.hereliesaz.kfizzix.dynamics.Fixture
+import com.github.hereliesaz.kfizzix.dynamics.World
+import com.github.hereliesaz.kfizzix.dynamics.joints.Joint
+
+/**
+ * Serializer for kbox2d, used to serialize any aspect of the physics world.
+ *
+ * @author Daniel Murphy
+ */
+interface JbSerializer {
+    /**
+     * Sets the object signer for the serializer. This allows the user to
+     * specify a 'tag' for each main physics object, which is then referenced
+     * later at deserialization for the user.
+     *
+     * @param signer the object signer to use
+     */
+    fun setObjectSigner(signer: ObjectSigner)
+
+    /**
+     * Sets a listener for unsupported exceptions. If a listener is provided, the
+     * serializer will call the listener with the exception instead of throwing it.
+     * This allows the serialization process to continue even if some objects are not supported.
+     *
+     * @param listener the listener to use
+     */
+    fun setUnsupportedListener(listener: UnsupportedListener)
+
+    /**
+     * Serializes the given [World].
+     *
+     * @param world the world to serialize
+     * @return the result of the serialization
+     * @throws UnsupportedObjectException if a physics object is unsupported and no listener is set.
+     * @see [setUnsupportedListener]
+     */
+    @Throws(UnsupportedObjectException::class)
+    fun serialize(world: World): SerializationResult
+
+    /**
+     * Serializes a given [Body].
+     *
+     * @param body the body to serialize
+     * @return the result of the serialization
+     * @throws UnsupportedObjectException if a physics object is unsupported and no listener is set.
+     * @see [setUnsupportedListener]
+     */
+    @Throws(UnsupportedObjectException::class)
+    fun serialize(body: Body): SerializationResult
+
+    /**
+     * Serializes a given [Fixture].
+     *
+     * @param fixture the fixture to serialize
+     * @return the result of the serialization
+     * @throws UnsupportedObjectException if a physics object is unsupported and no listener is set.
+     * @see [setUnsupportedListener]
+     */
+    @Throws(UnsupportedObjectException::class)
+    fun serialize(fixture: Fixture): SerializationResult
+
+    /**
+     * Serializes a given [Shape].
+     *
+     * @param shape the shape to serialize
+     * @return the result of the serialization
+     * @throws UnsupportedObjectException if a physics object is unsupported and no listener is set.
+     * @see [setUnsupportedListener]
+     */
+    @Throws(UnsupportedObjectException::class)
+    fun serialize(shape: Shape): SerializationResult
+
+    /**
+     * Serializes a given [Joint].
+     * Joints need to reference bodies and sometimes other joints, so this method requires maps
+     * to look up the indices of these objects.
+     *
+     * @param joint the joint to serialize
+     * @param bodyIndexMap a map from bodies to their indices
+     * @param jointIndexMap a map from joints to their indices
+     * @return the result of the serialization
+     */
+    fun serialize(joint: Joint, bodyIndexMap: Map<Body, Int>, jointIndexMap: Map<Joint, Int>): SerializationResult
+
+    /**
+     * Interface that allows the serializer to look up tags for each object,
+     * which can be used later during deserializing by the developer.
+     *
+     * @author Daniel Murphy
+     */
+    interface ObjectSigner {
+        /**
+         * Gets the tag for the given [World].
+         *
+         * @param world the world
+         * @return the tag for the world, or null if no tag is associated
+         */
+        fun getTag(world: World): Long?
+
+        /**
+         * Gets the tag for the given [Body].
+         *
+         * @param body the body
+         * @return the tag for the body, or null if no tag is associated
+         */
+        fun getTag(body: Body): Long?
+
+        /**
+         * Gets the tag for the given [Shape].
+         *
+         * @param shape the shape
+         * @return the tag for the shape, or null if no tag is associated
+         */
+        fun getTag(shape: Shape): Long?
+
+        /**
+         * Gets the tag for the given [Fixture].
+         *
+         * @param fixture the fixture
+         * @return the tag for the fixture, or null if no tag is associated
+         */
+        fun getTag(fixture: Fixture): Long?
+
+        /**
+         * Gets the tag for the given [Joint].
+         *
+         * @param joint the joint
+         * @return the tag for the joint, or null if no tag is associated
+         */
+        fun getTag(joint: Joint): Long?
+    }
+}

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/serialization/SerializationHelper.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/serialization/SerializationHelper.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2013, Daniel Murphy
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 	* Redistributions of source code must retain the above copyright notice,
+ * 	  this list of conditions and the following disclaimer.
+ * 	* Redistributions in binary form must reproduce the above copyright notice,
+ * 	  this list of conditions and the following disclaimer in the documentation
+ * 	  and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT of THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.github.hereliesaz.kfizzix.serialization
+
+import com.github.hereliesaz.kfizzix.dynamics.joints.JointType
+
+/**
+ * A collection of helper functions for serialization.
+ */
+object SerializationHelper {
+    /**
+     * Checks if a joint type is independent.
+     * Independent joints can be serialized without needing to reference other joints.
+     *
+     * @param type the joint type to check
+     * @return true if the joint type is independent, false otherwise
+     */
+    fun isIndependentJoint(type: JointType): Boolean {
+        return type != JointType.GEAR && type != JointType.CONSTANT_VOLUME
+    }
+}

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/serialization/SerializationResult.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/serialization/SerializationResult.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2013, Daniel Murphy
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 	* Redistributions of source code must retain the above copyright notice,
+ * 	  this list of conditions and the following disclaimer.
+ * 	* Redistributions in binary form must reproduce the above copyright notice,
+ * 	  this list of conditions and the following disclaimer in the documentation
+ * 	  and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.github.hereliesaz.kfizzix.serialization
+
+import java.io.IOException
+import java.io.OutputStream
+
+/**
+ * Container for holding serialization results. Use [.getValue] to get
+ * the implementation-specific result.
+ *
+ * @author Daniel Murphy
+ */
+interface SerializationResult {
+    /**
+     * The implementation-specific serialization result.
+     *
+     * @return serialization result
+     */
+    fun getValue(): Any
+
+    /**
+     * Writes the result to the given output stream.
+     */
+    @Throws(IOException::class)
+    fun writeTo(argOutputStream: OutputStream)
+}

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/serialization/UnsupportedListener.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/serialization/UnsupportedListener.kt
@@ -1,0 +1,18 @@
+package com.github.hereliesaz.kfizzix.serialization
+
+/**
+ * Used to hear when an object is unsupported by the serializer or the
+ * deserializer. This is so the de/serializer can keep going without throwing an
+ * exception and stopping the entire thing
+ *
+ * @author Daniel Murphy
+ */
+interface UnsupportedListener {
+    /**
+     * Called when an object is unsupported by the de/serializer.
+     *
+     * @param argException The exception describing the error.
+     * @return if the process should stop and the exception be thrown.
+     */
+    fun isUnsupported(argException: UnsupportedObjectException): Boolean
+}

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/serialization/UnsupportedObjectException.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/serialization/UnsupportedObjectException.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2013, Daniel Murphy
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 	* Redistributions of source code must retain the above copyright notice,
+ * 	  this list of conditions and the following disclaimer.
+ * 	* Redistributions in binary form must reproduce the above copyright notice,
+ * 	  this list of conditions and the following disclaimer in the documentation
+ * 	  and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.github.hereliesaz.kfizzix.serialization
+
+import java.io.Serial
+
+/**
+ * Called when an object is unsupported by the serializer or deserializer.
+ * Pertains to shapes, joints and other objects that might not be in some
+ * versions of the engine.
+ *
+ * @author Daniel Murphy
+ */
+class UnsupportedObjectException : RuntimeException {
+
+    enum class Type {
+        BODY, JOINT, SHAPE, OTHER
+    }
+
+    var type: Type? = null
+
+    constructor() : super()
+    constructor(argMessage: String?, argType: Type?) : super(argMessage) {
+        type = argType
+    }
+
+    constructor(argThrowable: Throwable?) : super(argThrowable)
+    constructor(argMessage: String?, argThrowable: Throwable?) : super(argMessage, argThrowable)
+
+    override fun getLocalizedMessage(): String {
+        return message + " [" + type + "]"
+
+    }
+
+    companion object {
+        @Serial
+        private const val serialVersionUID = 5915827472093183385L
+    }
+}

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/serialization/pb/PbDeserializer.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/serialization/pb/PbDeserializer.kt
@@ -1,0 +1,436 @@
+/*
+ * Copyright (c) 2013, Daniel Murphy
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 	* Redistributions of source code must retain the above copyright notice,
+ * 	  this list of conditions and the following disclaimer.
+ * 	* Redistributions in binary form must reproduce the above copyright notice,
+ * 	  this list of conditions and the following disclaimer in the documentation
+ * 	  and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.github.hereliesaz.kfizzix.serialization.pb
+
+import com.github.hereliesaz.kfizzix.collision.shapes.*
+import com.github.hereliesaz.kfizzix.common.Vec2
+import com.github.hereliesaz.kfizzix.dynamics.*
+import com.github.hereliesaz.kfizzix.dynamics.joints.*
+import com.github.hereliesaz.kfizzix.serialization.JbDeserializer
+import com.github.hereliesaz.kfizzix.serialization.UnsupportedListener
+import com.github.hereliesaz.kfizzix.serialization.UnsupportedObjectException
+import com.github.hereliesaz.kfizzix.serialization.UnsupportedObjectException.Type
+import org.box2d.proto.Box2D.*
+import java.io.IOException
+import java.io.InputStream
+
+class PbDeserializer : JbDeserializer {
+    private var listener: JbDeserializer.ObjectListener? = null
+    private var unsupportedlistener: UnsupportedListener? = null
+
+    constructor()
+    constructor(argListener: UnsupportedListener?) {
+        unsupportedlistener = argListener
+    }
+
+    constructor(argObjectListener: JbDeserializer.ObjectListener?) {
+        listener = argObjectListener
+    }
+
+    constructor(argListener: UnsupportedListener?, argObjectListener: JbDeserializer.ObjectListener?) {
+        unsupportedlistener = argListener
+        listener = argObjectListener
+    }
+
+    override fun setObjectListener(argListener: JbDeserializer.ObjectListener) {
+        listener = argListener
+    }
+
+    override fun setUnsupportedListener(argListener: UnsupportedListener) {
+        unsupportedlistener = argListener
+    }
+
+    private fun isIndependentJoint(argType: PbJointType): Boolean {
+        return argType != PbJointType.GEAR && argType != PbJointType.CONSTANT_VOLUME
+    }
+
+    @Throws(IOException::class)
+    override fun deserializeWorld(argInput: InputStream): World {
+        val world = PbWorld.parseFrom(argInput)
+        return deserializeWorld(world)
+    }
+
+    fun deserializeWorld(pbWorld: PbWorld): World {
+        val world = World(pbToVec(pbWorld.gravity))
+        world.isAutoClearForces = pbWorld.autoClearForces
+        world.isContinuousPhysics = pbWorld.continuousPhysics
+        world.isWarmStarting = pbWorld.warmStarting
+        world.isSubStepping = pbWorld.subStepping
+        val bodyMap = HashMap<Int, Body>()
+        val jointMap = HashMap<Int, Joint>()
+        for (i in 0 until pbWorld.bodiesCount) {
+            val pbBody = pbWorld.getBodies(i)
+            val body = deserializeBody(world, pbBody)
+            bodyMap[i] = body
+        }
+        // first pass, independent joints
+        var cnt = 0
+        for (i in 0 until pbWorld.jointsCount) {
+            val pbJoint = pbWorld.getJoints(i)
+            if (isIndependentJoint(pbJoint.type)) {
+                val joint = deserializeJoint(world, pbJoint, bodyMap,
+                        jointMap)
+                jointMap[cnt] = joint
+                cnt++
+            }
+        }
+        // second pass, dependent joints
+        for (i in 0 until pbWorld.jointsCount) {
+            val pbJoint = pbWorld.getJoints(i)
+            if (!isIndependentJoint(pbJoint.type)) {
+                val joint = deserializeJoint(world, pbJoint, bodyMap,
+                        jointMap)
+                jointMap[cnt] = joint
+                cnt++
+            }
+        }
+        if (listener != null && pbWorld.hasTag()) {
+            listener!!.processWorld(world, pbWorld.tag)
+        }
+        return world
+    }
+
+    @Throws(IOException::class)
+    override fun deserializeBody(argWorld: World, argInput: InputStream): Body {
+        val body = PbBody.parseFrom(argInput)
+        return deserializeBody(argWorld, body)
+    }
+
+    fun deserializeBody(argWorld: World, argBody: PbBody): Body {
+        val bd = BodyDef()
+        bd.position.set(pbToVec(argBody.position))
+        bd.angle = argBody.angle
+        bd.linearDamping = argBody.linearDamping
+        bd.angularDamping = argBody.angularDamping
+        bd.gravityScale = argBody.gravityScale
+        // velocities are populated after fixture addition
+        bd.bullet = argBody.bullet
+        bd.allowSleep = argBody.allowSleep
+        bd.awake = argBody.awake
+        bd.active = argBody.active
+        bd.fixedRotation = argBody.fixedRotation
+        when (argBody.type) {
+            PbBodyType.DYNAMIC -> bd.type = BodyType.DYNAMIC
+            PbBodyType.KINEMATIC -> bd.type = BodyType.KINEMATIC
+            PbBodyType.STATIC -> bd.type = BodyType.STATIC
+            else -> {
+                val e = UnsupportedObjectException(
+                        "Unknown body type: " + argBody.type, Type.BODY)
+                if (unsupportedlistener == null
+                        || unsupportedlistener!!.isUnsupported(e)) {
+                    throw e
+                }
+                throw e
+            }
+        }
+        val body = argWorld.createBody(bd)
+        for (i in 0 until argBody.fixturesCount) {
+            deserializeFixture(body, argBody.getFixtures(i))
+        }
+        // adding fixtures can change this, so we put this here and set it
+// directly in the body
+        body.linearVelocity.set(pbToVec(argBody.linearVelocity))
+        body.angularVelocity = argBody.angularVelocity
+        if (listener != null && argBody.hasTag()) {
+            listener!!.processBody(body, argBody.tag)
+        }
+        return body
+    }
+
+    @Throws(IOException::class)
+    override fun deserializeFixture(argBody: Body, argInput: InputStream): Fixture {
+        val fixture = PbFixture.parseFrom(argInput)
+        return deserializeFixture(argBody, fixture)
+    }
+
+    fun deserializeFixture(argBody: Body, argFixture: PbFixture): Fixture {
+        val fd = FixtureDef()
+        fd.density = argFixture.density
+        fd.filter.categoryBits = argFixture.filter.categoryBits
+        fd.filter.groupIndex = argFixture.filter.groupIndex
+        fd.filter.maskBits = argFixture.filter.maskBits
+        fd.friction = argFixture.friction
+        fd.isSensor = argFixture.sensor
+        fd.restitution = argFixture.restitution
+        fd.shape = deserializeShape(argFixture.shape)
+        val fixture = argBody.createFixture(fd)
+        if (listener != null && argFixture.hasTag()) {
+            listener!!.processFixture(fixture, argFixture.tag)
+        }
+        return fixture
+    }
+
+    @Throws(IOException::class)
+    override fun deserializeShape(argInput: InputStream): Shape {
+        val s = PbShape.parseFrom(argInput)
+        return deserializeShape(s)
+    }
+
+    fun deserializeShape(argShape: PbShape): Shape {
+        val shape: Shape
+        when (argShape.type) {
+            PbShapeType.CIRCLE -> {
+                val c = CircleShape()
+                c.p.set(pbToVec(argShape.center))
+                shape = c
+            }
+            PbShapeType.POLYGON -> {
+                val p = PolygonShape()
+                p.centroid.set(pbToVec(argShape.centroid))
+                p.count = argShape.pointsCount
+                for (i in 0 until p.count) {
+                    p.vertices[i].set(pbToVec(argShape.getPoints(i)))
+                    p.normals[i].set(pbToVec(argShape.getNormals(i)))
+                }
+                shape = p
+            }
+            PbShapeType.EDGE -> {
+                val edge = EdgeShape()
+                edge.vertex0.set(pbToVec(argShape.v0))
+                edge.vertex1.set(pbToVec(argShape.v1))
+                edge.vertex2.set(pbToVec(argShape.v2))
+                edge.vertex3.set(pbToVec(argShape.v3))
+                edge.m_hasVertex0 = argShape.has0
+                edge.m_hasVertex3 = argShape.has3
+                shape = edge
+            }
+            PbShapeType.CHAIN -> {
+                val chain = ChainShape()
+                chain.m_count = argShape.pointsCount
+                chain.m_vertices = Array(chain.m_count) { Vec2() }
+                for (i in 0 until chain.m_count) {
+
+                    chain.m_vertices!![i] = Vec2(pbToVec(argShape.getPoints(i)))
+
+                }
+                chain.m_hasPrevVertex = argShape.has0
+                chain.m_hasNextVertex = argShape.has3
+                chain.m_prevVertex.set(pbToVec(argShape.prev))
+                chain.m_nextVertex.set(pbToVec(argShape.next))
+                shape = chain
+            }
+            else -> {
+                val e = UnsupportedObjectException(
+                        "Unknown shape type: " + argShape.type, Type.SHAPE)
+                if (unsupportedlistener == null
+                        || unsupportedlistener!!.isUnsupported(e)) {
+                    throw e
+                }
+                throw e
+            }
+        }
+        shape.radius = argShape.radius
+        if (listener != null && argShape.hasTag()) {
+            listener!!.processShape(shape, argShape.tag)
+        }
+        return shape
+    }
+
+    @Throws(IOException::class)
+    override fun deserializeJoint(argWorld: World, argInput: InputStream,
+                                  argBodyMap: Map<Int, Body>, jointMap: Map<Int, Joint>): Joint {
+        val joint = PbJoint.parseFrom(argInput)
+        return deserializeJoint(argWorld, joint, argBodyMap, jointMap)
+    }
+
+    fun deserializeJoint(argWorld: World, joint: PbJoint,
+                         argBodyMap: Map<Int, Body>, jointMap: Map<Int, Joint>): Joint {
+        val jd: JointDef
+        when (joint.type) {
+            PbJointType.PRISMATIC -> {
+                val def = PrismaticJointDef()
+                jd = def
+                def.enableLimit = joint.enableLimit
+                def.enableMotor = joint.enableMotor
+                def.localAnchorA.set(pbToVec(joint.localAnchorA))
+                def.localAnchorB.set(pbToVec(joint.localAnchorB))
+                def.localAxisA.set(pbToVec(joint.localAxisA))
+                def.lowerTranslation = joint.lowerLimit
+                def.maxMotorForce = joint.maxMotorForce
+                def.motorSpeed = joint.motorSpeed
+                def.referenceAngle = joint.refAngle
+                def.upperTranslation = joint.upperLimit
+            }
+            PbJointType.REVOLUTE -> {
+                val def = RevoluteJointDef()
+                jd = def
+                def.enableLimit = joint.enableLimit
+                def.enableMotor = joint.enableMotor
+                def.localAnchorA.set(pbToVec(joint.localAnchorA))
+                def.localAnchorB.set(pbToVec(joint.localAnchorB))
+                def.lowerAngle = joint.lowerLimit
+                def.maxMotorTorque = joint.maxMotorTorque
+                def.motorSpeed = joint.motorSpeed
+                def.referenceAngle = joint.refAngle
+                def.upperAngle = joint.upperLimit
+            }
+            PbJointType.DISTANCE -> {
+                val def = DistanceJointDef()
+                jd = def
+                def.localAnchorA.set(pbToVec(joint.localAnchorA))
+                def.localAnchorB.set(pbToVec(joint.localAnchorB))
+                def.dampingRatio = joint.dampingRatio
+                def.frequencyHz = joint.frequency
+                def.length = joint.length
+            }
+            PbJointType.PULLEY -> {
+                val def = PulleyJointDef()
+                jd = def
+                def.localAnchorA.set(pbToVec(joint.localAnchorA))
+                def.localAnchorB.set(pbToVec(joint.localAnchorB))
+                def.groundAnchorA.set(pbToVec(joint.groundAnchorA))
+                def.groundAnchorB.set(pbToVec(joint.groundAnchorB))
+                def.lengthA = joint.lengthA
+                def.lengthB = joint.lengthB
+                def.ratio = joint.ratio
+            }
+            PbJointType.MOUSE -> {
+                val def = MouseJointDef()
+                jd = def
+                def.dampingRatio = joint.dampingRatio
+                def.frequencyHz = joint.frequency
+                def.maxForce = joint.maxForce
+                def.target.set(pbToVec(joint.target))
+            }
+            PbJointType.GEAR -> {
+                val def = GearJointDef()
+                jd = def
+                if (!jointMap.containsKey(joint.joint1)) {
+                    throw IllegalArgumentException("Index " + joint.joint1
+                            + " is not present in the joint map.")
+                }
+                def.joint1 = jointMap[joint.joint1]
+                if (!jointMap.containsKey(joint.joint2)) {
+                    throw IllegalArgumentException("Index " + joint.joint2
+                            + " is not present in the joint map.")
+                }
+                def.joint2 = jointMap[joint.joint2]
+                def.ratio = joint.ratio
+            }
+            PbJointType.WHEEL -> {
+                val def = WheelJointDef()
+                jd = def
+                def.localAnchorA.set(pbToVec(joint.localAnchorA))
+                def.localAnchorB.set(pbToVec(joint.localAnchorB))
+                def.localAxisA.set(pbToVec(joint.localAxisA))
+                def.enableMotor = joint.enableMotor
+                def.maxMotorTorque = joint.maxMotorTorque
+                def.motorSpeed = joint.motorSpeed
+                def.frequencyHz = joint.frequency
+                def.dampingRatio = joint.dampingRatio
+            }
+            PbJointType.WELD -> {
+                val def = WeldJointDef()
+                jd = def
+                def.localAnchorA.set(pbToVec(joint.localAnchorA))
+                def.localAnchorB.set(pbToVec(joint.localAnchorB))
+                def.referenceAngle = joint.refAngle
+                def.frequencyHz = joint.frequency
+                def.dampingRatio = joint.dampingRatio
+            }
+            PbJointType.FRICTION -> {
+                val def = FrictionJointDef()
+                jd = def
+                def.localAnchorA.set(pbToVec(joint.localAnchorA))
+                def.localAnchorB.set(pbToVec(joint.localAnchorB))
+                def.maxForce = joint.maxForce
+                def.maxTorque = joint.maxTorque
+            }
+            PbJointType.ROPE -> {
+                val def = RopeJointDef()
+                def.localAnchorA.set(pbToVec(joint.localAnchorA))
+                def.localAnchorB.set(pbToVec(joint.localAnchorB))
+                def.maxLength = joint.maxLength
+                throw UnsupportedObjectException("Rope joint not supported yet", Type.JOINT)
+            }
+            PbJointType.CONSTANT_VOLUME -> {
+                val def = ConstantVolumeJointDef()
+                jd = def
+                def.dampingRatio = joint.dampingRatio
+                def.frequencyHz = joint.frequency
+                if (joint.bodiesCount != joint.jointsCount) {
+                    throw IllegalArgumentException(
+                            "Constant volume joint must have bodies and joints defined")
+                }
+                for (i in 0 until joint.bodiesCount) {
+                    val body = joint.getBodies(i)
+                    if (!argBodyMap.containsKey(body)) {
+                        throw IllegalArgumentException("Index " + body
+                                + " is not present in the body map")
+                    }
+                    val jointIndex = joint.getJoints(i)
+                    if (!jointMap.containsKey(jointIndex)) {
+                        throw IllegalArgumentException("Index " + jointIndex
+                                + " is not present in the joint map")
+                    }
+                    val djoint = jointMap[jointIndex]
+                    if (djoint !is DistanceJoint) {
+                        throw IllegalArgumentException(
+                                "Joints for constant volume joint must be distance joints")
+                    }
+                    def.addBodyAndJoint(argBodyMap[body],
+                            djoint as DistanceJoint)
+                }
+            }
+            PbJointType.LINE -> {
+                val e = UnsupportedObjectException(
+                        "Line joint no longer supported.", Type.JOINT)
+                if (unsupportedlistener == null
+                        || unsupportedlistener!!.isUnsupported(e)) {
+                    throw e
+                }
+                throw e
+            }
+            else -> {
+                val e = UnsupportedObjectException(
+                        "Unknown joint type: " + joint.type, Type.JOINT)
+                if (unsupportedlistener == null
+                        || unsupportedlistener!!.isUnsupported(e)) {
+                    throw e
+                }
+                throw e
+            }
+        }
+        jd.collideConnected = joint.collideConnected
+        if (!argBodyMap.containsKey(joint.bodyA)) {
+            throw IllegalArgumentException("Index " + joint.bodyA
+                    + " is not present in the body map")
+        }
+        jd.bodyA = argBodyMap[joint.bodyA]
+        if (!argBodyMap.containsKey(joint.bodyB)) {
+            throw IllegalArgumentException("Index " + joint.bodyB
+                    + " is not present in the body map")
+        }
+        jd.bodyB = argBodyMap[joint.bodyB]
+        val realJoint = argWorld.createJoint(jd)
+        if (listener != null && joint.hasTag()) {
+            listener!!.processJoint(realJoint, joint.tag)
+        }
+        return realJoint
+    }
+
+    private fun pbToVec(argVec: PbVec2): Vec2 {
+        return Vec2(argVec.x, argVec.y)
+    }
+}

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/serialization/pb/PbSerializer.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/serialization/pb/PbSerializer.kt
@@ -1,0 +1,482 @@
+/*
+ * Copyright (c) 2013, Daniel Murphy
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 	* Redistributions of source code must retain the above copyright notice,
+ * 	  this list of conditions and the following disclaimer.
+ * 	* Redistributions in binary form must reproduce the above copyright notice,
+ * 	  this list of conditions and the following disclaimer in the documentation
+ * 	  and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.github.hereliesaz.kfizzix.serialization.pb
+
+import com.github.hereliesaz.kfizzix.collision.shapes.*
+import com.github.hereliesaz.kfizzix.common.Vec2
+import com.github.hereliesaz.kfizzix.dynamics.*
+import com.github.hereliesaz.kfizzix.dynamics.joints.*
+import com.github.hereliesaz.kfizzix.serialization.*
+import com.github.hereliesaz.kfizzix.serialization.UnsupportedObjectException.Type
+import org.box2d.proto.Box2D.*
+import java.io.IOException
+import java.io.OutputStream
+
+/**
+ * Protobuffer serializer implementation.
+ *
+ * @author Daniel Murphy
+ */
+class PbSerializer : JbSerializer {
+    private var signer: JbSerializer.ObjectSigner? = null
+    private var listener: UnsupportedListener? = null
+
+    constructor()
+    constructor(argListener: UnsupportedListener?) {
+        listener = argListener
+    }
+
+    constructor(argSigner: JbSerializer.ObjectSigner?) {
+        signer = argSigner
+    }
+
+    constructor(argListener: UnsupportedListener?, argSigner: JbSerializer.ObjectSigner?) {
+        listener = argListener
+        signer = argSigner
+    }
+
+    override fun setObjectSigner(argSigner: JbSerializer.ObjectSigner) {
+        signer = argSigner
+    }
+
+    override fun setUnsupportedListener(argListener: UnsupportedListener) {
+        listener = argListener
+    }
+
+    override fun serialize(argWorld: World): SerializationResult {
+        val world = serializeWorld(argWorld).build()
+        return object : SerializationResult {
+            @Throws(IOException::class)
+            override fun writeTo(argOutputStream: OutputStream) {
+                world.writeTo(argOutputStream)
+            }
+
+            override fun getValue(): Any {
+                return world
+            }
+        }
+    }
+
+    fun serializeWorld(argWorld: World): PbWorld.Builder {
+        val builder = PbWorld.newBuilder()
+        if (signer != null) {
+            val tag = signer!!.getTag(argWorld)
+            if (tag != null) {
+                builder.tag = tag
+            }
+        }
+        builder.setGravity(vecToPb(argWorld.gravity))
+        builder.autoClearForces = argWorld.isAutoClearForces
+        builder.allowSleep = argWorld.isAllowSleep
+        builder.isContinuousPhysics = argWorld.isContinuousPhysics
+        builder.isWarmStarting = argWorld.isWarmStarting
+        builder.isSubStepping = argWorld.isSubStepping
+        var cbody = argWorld.bodyList
+        var cnt = 0
+        val bodies = HashMap<Body, Int>()
+        while (cbody != null) {
+            builder.addBodies(serializeBody(cbody))
+            bodies[cbody] = cnt
+            cnt++
+            cbody = cbody.next
+        }
+        cnt = 0
+        val joints = HashMap<Joint, Int>()
+        var cjoint = argWorld.jointList
+        // first pass
+        while (cjoint != null) {
+            if (SerializationHelper.isIndependentJoint(cjoint.type)) {
+                builder.addJoints(serializeJoint(cjoint, bodies, joints))
+                joints[cjoint] = cnt
+                cnt++
+            }
+            cjoint = cjoint.next
+        }
+        // second pass for dependent joints
+        cjoint = argWorld.jointList
+        while (cjoint != null) {
+            if (!SerializationHelper.isIndependentJoint(cjoint.type)) {
+                builder.addJoints(serializeJoint(cjoint, bodies, joints))
+                joints[cjoint] = cnt
+                cnt++
+            }
+            cjoint = cjoint.next
+        }
+        return builder
+    }
+
+    override fun serialize(argBody: Body): SerializationResult {
+        val builder = serializeBody(argBody)
+        val body = builder.build()
+        return object : SerializationResult {
+            @Throws(IOException::class)
+            override fun writeTo(argOutputStream: OutputStream) {
+                body.writeTo(argOutputStream)
+            }
+
+            override fun getValue(): Any {
+                return body
+            }
+        }
+    }
+
+    fun serializeBody(argBody: Body): PbBody.Builder {
+        val builder = PbBody.newBuilder()
+        if (signer != null) {
+            val id = signer!!.getTag(argBody)
+            if (id != null) {
+                builder.tag = id
+            }
+        }
+        when (argBody.type) {
+            BodyType.DYNAMIC -> builder.type = PbBodyType.DYNAMIC
+            BodyType.KINEMATIC -> builder.type = PbBodyType.KINEMATIC
+            BodyType.STATIC -> builder.type = PbBodyType.STATIC
+            else -> {
+                val e = UnsupportedObjectException(
+                        "Unknown body type: " + argBody.type, Type.BODY)
+                if (listener == null || listener!!.isUnsupported(e)) {
+                    throw e
+                }
+                throw e
+            }
+        }
+        builder.setPosition(vecToPb(argBody.position))
+        builder.angle = argBody.angle
+        builder.setLinearVelocity(vecToPb(argBody.linearVelocity))
+        builder.angularVelocity = argBody.angularVelocity
+        builder.linearDamping = argBody.linearDamping
+        builder.angularDamping = argBody.angularDamping
+        builder.gravityScale = argBody.gravityScale
+        builder.bullet = argBody.isBullet
+        builder.allowSleep = argBody.isSleepingAllowed
+        builder.awake = argBody.isAwake
+        builder.isActive = argBody.isActive
+        builder.fixedRotation = argBody.isFixedRotation
+        var curr = argBody.fixtureList
+        while (curr != null) {
+            builder.addFixtures(serializeFixture(curr))
+            curr = curr.next
+        }
+        return builder
+    }
+
+    override fun serialize(argFixture: Fixture): SerializationResult {
+        val fixture = serializeFixture(argFixture).build()
+        return object : SerializationResult {
+            @Throws(IOException::class)
+            override fun writeTo(argOutputStream: OutputStream) {
+                fixture.writeTo(argOutputStream)
+            }
+
+            override fun getValue(): Any {
+                return fixture
+            }
+        }
+    }
+
+    fun serializeFixture(argFixture: Fixture): PbFixture.Builder {
+        val builder = PbFixture.newBuilder()
+        if (signer != null) {
+            val tag = signer!!.getTag(argFixture)
+            if (tag != null) {
+                builder.tag = tag
+            }
+        }
+        builder.density = argFixture.density
+        builder.friction = argFixture.friction
+        builder.restitution = argFixture.restitution
+        builder.sensor = argFixture.isSensor
+        builder.setShape(serializeShape(argFixture.shape))
+        builder.setFilter(serializeFilter(argFixture.filter))
+        return builder
+    }
+
+    override fun serialize(argShape: Shape): SerializationResult {
+        val builder = serializeShape(argShape)
+// should we do lazy building?
+        val shape = builder.build()
+        return object : SerializationResult {
+            @Throws(IOException::class)
+            override fun writeTo(argOutputStream: OutputStream) {
+                shape.writeTo(argOutputStream)
+            }
+
+            override fun getValue(): Any {
+                return shape
+            }
+        }
+    }
+
+    fun serializeShape(argShape: Shape): PbShape.Builder {
+        val builder = PbShape.newBuilder()
+        if (signer != null) {
+            val tag = signer!!.getTag(argShape)
+            if (tag != null) {
+                builder.tag = tag
+            }
+        }
+        builder.radius = argShape.radius
+        when (argShape.type) {
+            ShapeType.CIRCLE -> {
+                val c = argShape as CircleShape
+                builder.type = PbShapeType.CIRCLE
+                builder.setCenter(vecToPb(c.p))
+            }
+            ShapeType.POLYGON -> {
+                val p = argShape as PolygonShape
+                builder.type = PbShapeType.POLYGON
+                builder.setCentroid(vecToPb(p.centroid))
+                for (i in 0 until p.count) {
+                    builder.addPoints(vecToPb(p.vertices[i]))
+                    builder.addNormals(vecToPb(p.normals[i]))
+                }
+            }
+            ShapeType.EDGE -> {
+                val e = argShape as EdgeShape
+                builder.type = PbShapeType.EDGE
+                builder.setV0(vecToPb(e.vertex0))
+                builder.setV1(vecToPb(e.vertex1))
+                builder.setV2(vecToPb(e.vertex2))
+                builder.setV3(vecToPb(e.vertex3))
+                builder.setHas0(e.m_hasVertex0)
+                builder.setHas3(e.m_hasVertex3)
+            }
+            ShapeType.CHAIN -> {
+                val h = argShape as ChainShape
+                builder.type = PbShapeType.CHAIN
+                for (i in 0 until h.m_count) {
+                    builder.addPoints(vecToPb(h.m_vertices!![i]))
+                }
+                builder.setPrev(vecToPb(h.m_prevVertex))
+                builder.setNext(vecToPb(h.m_nextVertex))
+                builder.setHas0(h.m_hasPrevVertex)
+                builder.setHas3(h.m_hasNextVertex)
+            }
+            else -> {
+                val ex = UnsupportedObjectException(
+                        "Currently only encodes circle and polygon shapes",
+                        Type.SHAPE)
+                if (listener == null || listener!!.isUnsupported(ex)) {
+                    throw ex
+                }
+                throw ex
+            }
+        }
+        return builder
+    }
+
+    override fun serialize(argJoint: Joint, argBodyIndexMap: Map<Body, Int>,
+                           argJointIndexMap: Map<Joint, Int>): SerializationResult {
+        val builder = serializeJoint(argJoint, argBodyIndexMap,
+                argJointIndexMap)
+        val joint = builder.build()
+        return object : SerializationResult {
+            @Throws(IOException::class)
+            override fun writeTo(argOutputStream: OutputStream) {
+                joint.writeTo(argOutputStream)
+            }
+
+            override fun getValue(): Any {
+                return joint
+            }
+        }
+    }
+
+    fun serializeJoint(joint: Joint,
+                       argBodyIndexMap: Map<Body, Int>,
+                       argJointIndexMap: Map<Joint, Int>): PbJoint.Builder {
+        val builder = PbJoint.newBuilder()
+        if (signer != null) {
+            val tag = signer!!.getTag(joint)
+            if (tag != null) {
+                builder.tag = tag
+            } else {
+                builder.clearTag()
+            }
+        }
+        val bA = joint.bodyA
+        val bB = joint.bodyB
+        if (!argBodyIndexMap.containsKey(bA)) {
+            throw IllegalArgumentException(
+                    "Body $bA is not present in the index map")
+        }
+        builder.setBodyA(argBodyIndexMap[bA]!!)
+        if (!argBodyIndexMap.containsKey(bB)) {
+            throw IllegalArgumentException(
+                    "Body $bB is not present in the index map")
+        }
+        builder.setBodyB(argBodyIndexMap[bB]!!)
+        builder.collideConnected = joint.collideConnected
+        when (joint.type) {
+            JointType.REVOLUTE -> {
+                val j = joint as RevoluteJoint
+                builder.type = PbJointType.REVOLUTE
+                builder.setLocalAnchorA(vecToPb(j.localAnchorA))
+                builder.setLocalAnchorB(vecToPb(j.localAnchorB))
+                builder.refAngle = j.referenceAngle
+                builder.enableLimit = j.isLimitEnabled
+                builder.lowerLimit = j.lowerLimit
+                builder.upperLimit = j.upperLimit
+                builder.enableMotor = j.isMotorEnabled
+                builder.motorSpeed = j.motorSpeed
+                builder.maxMotorTorque = j.maxMotorTorque
+            }
+            JointType.PRISMATIC -> {
+                val j = joint as PrismaticJoint
+                builder.type = PbJointType.PRISMATIC
+                builder.setLocalAnchorA(vecToPb(j.localAnchorA))
+                builder.setLocalAnchorB(vecToPb(j.localAnchorB))
+                builder.setLocalAxisA(vecToPb(j.localAxisA))
+                builder.refAngle = j.referenceAngle
+                builder.enableLimit = j.isLimitEnabled
+                builder.lowerLimit = j.lowerLimit
+                builder.upperLimit = j.upperLimit
+                builder.enableMotor = j.isMotorEnabled
+                builder.maxMotorForce = j.maxMotorForce
+                builder.motorSpeed = j.motorSpeed
+            }
+            JointType.DISTANCE -> {
+                val j = joint as DistanceJoint
+                builder.type = PbJointType.DISTANCE
+                builder.setLocalAnchorA(vecToPb(j.localAnchorA))
+                builder.setLocalAnchorB(vecToPb(j.localAnchorB))
+                builder.length = j.length
+                builder.frequency = j.frequency
+                builder.dampingRatio = j.dampingRatio
+            }
+            JointType.PULLEY -> {
+                val j = joint as PulleyJoint
+                builder.type = PbJointType.PULLEY
+                builder.setLocalAnchorA(vecToPb(j.localAnchorA))
+                builder.setLocalAnchorB(vecToPb(j.localAnchorB))
+                builder.setGroundAnchorA(vecToPb(j.groundAnchorA))
+                builder.setGroundAnchorB(vecToPb(j.groundAnchorB))
+                builder.setLengthA(j.lengthA)
+                builder.setLengthB(j.lengthB)
+                builder.ratio = j.ratio
+            }
+            JointType.MOUSE -> {
+                val j = joint as MouseJoint
+                builder.type = PbJointType.MOUSE
+                builder.setTarget(vecToPb(j.target))
+                builder.maxForce = j.maxForce
+                builder.frequency = j.frequency
+                builder.dampingRatio = j.dampingRatio
+            }
+            JointType.GEAR -> {
+                val j = joint as GearJoint
+                builder.type = PbJointType.GEAR
+                builder.ratio = j.ratio
+                if (!argJointIndexMap.containsKey(j.joint1)) {
+                    throw IllegalArgumentException("Joint 1 not in map")
+                }
+                val j1 = argJointIndexMap[j.joint1]!!
+                if (!argJointIndexMap.containsKey(j.joint2)) {
+                    throw IllegalArgumentException("Joint 2 not in map")
+                }
+                val j2 = argJointIndexMap[j.joint2]!!
+                builder.setJoint1(j1)
+                builder.setJoint2(j2)
+            }
+            JointType.FRICTION -> {
+                val j = joint as FrictionJoint
+                builder.type = PbJointType.FRICTION
+                builder.setLocalAnchorA(vecToPb(j.localAnchorA))
+                builder.setLocalAnchorB(vecToPb(j.localAnchorB))
+                builder.maxForce = j.maxForce
+                builder.maxTorque = j.maxTorque
+            }
+            JointType.CONSTANT_VOLUME -> {
+                val j = joint as ConstantVolumeJoint
+                builder.type = PbJointType.CONSTANT_VOLUME
+                for (i in j.bodies.indices) {
+                    val b = j.bodies[i]
+                    val distanceJoint = j.joints[i]
+                    if (!argBodyIndexMap.containsKey(b)) {
+                        throw IllegalArgumentException(
+                                "Body $b is not present in the index map")
+                    }
+                    builder.addBodies(argBodyIndexMap[b]!!)
+                    if (!argJointIndexMap.containsKey(distanceJoint)) {
+                        throw IllegalArgumentException("Joint $distanceJoint is not present in the index map")
+                    }
+                    builder.addJoints(argJointIndexMap[distanceJoint]!!)
+                }
+            }
+            JointType.WHEEL -> {
+                val j = joint as WheelJoint
+                builder.type = PbJointType.WHEEL
+                builder.setLocalAnchorA(vecToPb(j.localAnchorA))
+                builder.setLocalAnchorB(vecToPb(j.localAnchorB))
+                builder.setLocalAxisA(vecToPb(j.localAxisA))
+                builder.enableMotor = j.isMotorEnabled
+                builder.maxMotorTorque = j.maxMotorTorque
+                builder.motorSpeed = j.motorSpeed
+                builder.frequency = j.springFrequencyHz
+                builder.dampingRatio = j.springDampingRatio
+            }
+            JointType.ROPE -> {
+                val j = joint as RopeJoint
+                builder.type = PbJointType.ROPE
+                builder.setLocalAnchorA(vecToPb(j.localAnchorA))
+                builder.setLocalAnchorB(vecToPb(j.localAnchorB))
+                builder.maxLength = j.maxLength
+            }
+            JointType.WELD -> {
+                val j = joint as WeldJoint
+                builder.type = PbJointType.WELD
+                builder.setLocalAnchorA(vecToPb(j.localAnchorA))
+                builder.setLocalAnchorB(vecToPb(j.localAnchorB))
+                builder.refAngle = j.referenceAngle
+                builder.frequency = j.frequency
+                builder.dampingRatio = j.dampingRatio
+            }
+            else -> {
+                val e = UnsupportedObjectException(
+                        "Unknown joint type: " + joint.type, Type.JOINT)
+                if (listener == null || listener!!.isUnsupported(e)) {
+                    throw e
+                }
+                throw e
+            }
+        }
+        return builder
+    }
+
+    fun serializeFilter(argFilter: Filter): PbFilter.Builder {
+        val builder = PbFilter.newBuilder()
+        builder.categoryBits = argFilter.categoryBits
+        builder.groupIndex = argFilter.groupIndex
+        builder.maskBits = argFilter.maskBits
+        return builder
+    }
+
+    private fun vecToPb(argVec: Vec2?): PbVec2? {
+        if (argVec == null) {
+            return null
+        }
+        return PbVec2.newBuilder().setX(argVec.x).setY(argVec.y).build()
+    }
+}

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/testbed/javafx/DebugDrawJavaFX.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/testbed/javafx/DebugDrawJavaFX.kt
@@ -1,0 +1,291 @@
+/*
+ * Copyright (c) 2013, Daniel Murphy All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met: * Redistributions of source code must retain the
+ * above copyright notice, this list of conditions and the following disclaimer. * Redistributions
+ * in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.github.hereliesaz.kfizzix.testbed.javafx
+
+import com.github.hereliesaz.kfizzix.callbacks.DebugDraw
+import com.github.hereliesaz.kfizzix.collision.AABB
+import com.github.hereliesaz.kfizzix.common.*
+import com.github.hereliesaz.kfizzix.particle.ParticleColor
+import com.github.hereliesaz.kfizzix.pooling.arrays.Vec2Array
+import com.github.hereliesaz.kfizzix.testbed.pooling.ColorPool
+import javafx.geometry.Rectangle2D
+import javafx.scene.canvas.GraphicsContext
+import javafx.scene.paint.Color
+import javafx.scene.transform.Affine
+
+/**
+ * Implementation of [DebugDraw] that uses JavaFX! Hooray!<br>
+ *
+ * @author Daniel Murphy Initial Java 2D implementation
+ * @author Hallvard Traetteberg JavaFX port
+ */
+class DebugDrawJavaFX(private val panel: TestPanelJavaFX, private val yFlip: Boolean) : DebugDraw() {
+    private val cpool: ColorPool<Color> = object : ColorPool<Color>() {
+        override fun newColor(r: Float, g: Float, b: Float, alpha: Float): Color {
+            return Color(r.toDouble(), g.toDouble(), b.toDouble(), alpha.toDouble())
+        }
+    }
+    private var circle: Rectangle2D
+    override fun setViewportTransform(viewportTransform: IViewportTransform) {
+        super.setViewportTransform(viewportTransform)
+        viewportTransform.isYFlip = yFlip
+    }
+
+    private val vec2Array = Vec2Array()
+    override fun drawPoint(argPoint: Vec2, argRadiusOnScreen: Float, argColor: Color3f) {
+        getWorldToScreenToOut(argPoint, sp1)
+        val g = graphics
+        val c = cpool.getColor(argColor.x, argColor.y, argColor.z)
+        g.stroke = c
+        sp1.x -= argRadiusOnScreen
+        sp1.y -= argRadiusOnScreen
+        g.fillOval(sp1.x.toDouble(), sp1.y.toDouble(), (argRadiusOnScreen * 2).toDouble(),
+                (argRadiusOnScreen * 2).toDouble())
+    }
+
+    private val sp1 = Vec2()
+    private val sp2 = Vec2()
+    override fun drawSegment(p1: Vec2, p2: Vec2, color: Color3f) {
+        getWorldToScreenToOut(p1, sp1)
+        getWorldToScreenToOut(p2, sp2)
+        val c = cpool.getColor(color.x, color.y, color.z)
+        val g = graphics
+        g.stroke = c
+        g.lineWidth = 0.0
+        g.strokeLine(sp1.x.toDouble(), sp1.y.toDouble(), sp2.x.toDouble(), sp2.y.toDouble())
+    }
+
+    fun drawAABB(argAABB: AABB, color: Color3f) {
+        val vecs = vec2Array[4]
+        argAABB.getVertices(vecs)
+        drawPolygon(vecs, 4, color)
+    }
+
+    private val tr = Affine()
+    private val oldTrans = Affine()
+    private var stroke: Double
+    private var oldStroke = 0.0
+    private fun saveState(g: GraphicsContext) {
+        oldTrans.setToTransform(g.transform)
+        oldStroke = g.lineWidth
+    }
+
+    private fun restoreState(g: GraphicsContext) {
+        g.transform = oldTrans
+        g.lineWidth = oldStroke
+    }
+
+    private fun transformGraphics(g: GraphicsContext, center: Vec2): Double {
+        val e = viewportTransform.extents
+        val vc = viewportTransform.center
+        val vt = viewportTransform.mat22Representation
+        val flip = if (yFlip) -1 else 1
+        tr.setToTransform(vt.ex.x.toDouble(), (flip * vt.ex.y).toDouble(), e.x.toDouble(), vt.ey.x.toDouble(), (flip * vt.ey.y).toDouble(),
+                e.y.toDouble())
+        tr.appendTranslation(-vc.x.toDouble(), -vc.y.toDouble())
+        tr.appendTranslation(center.x.toDouble(), center.y.toDouble())
+        g.transform = tr
+        return vt.ex.x.toDouble()
+    }
+
+    override fun drawCircle(center: Vec2, radius: Float, color: Color3f) {
+        val g = graphics
+        val s = cpool.getColor(color.x, color.y, color.z, 1.0f)
+        saveState(g)
+        val scaling = transformGraphics(g, center) * radius
+        g.lineWidth = stroke / scaling
+        g.scale(radius.toDouble(), radius.toDouble())
+        g.stroke = s
+        g.strokeOval(circle.minX, circle.minX, circle.width,
+                circle.height)
+        restoreState(g)
+    }
+
+    override fun drawCircle(center: Vec2, radius: Float, axis: Vec2, color: Color3f) {
+        val g = graphics
+        val s = cpool.getColor(color.x, color.y, color.z, 1f)
+        saveState(g)
+        val scaling = transformGraphics(g, center) * radius
+        g.lineWidth = stroke / scaling
+        g.scale(radius.toDouble(), radius.toDouble())
+        g.stroke = s
+        g.strokeOval(circle.minX, circle.minX, circle.width,
+                circle.height)
+        g.rotate(MathUtils.atan2(axis.y, axis.x).toDouble())
+        g.strokeLine(0.0, 0.0, 1.0, 0.0)
+        restoreState(g)
+    }
+
+    override fun drawSolidCircle(center: Vec2, radius: Float, axis: Vec2,
+                                 color: Color3f) {
+        val g = graphics
+        val f = cpool.getColor(color.x, color.y, color.z, .4f)
+        val s = cpool.getColor(color.x, color.y, color.z, 1f)
+        saveState(g)
+        val scaling = transformGraphics(g, center) * radius
+        g.lineWidth = stroke / scaling
+        g.scale(radius.toDouble(), radius.toDouble())
+        g.fill = f
+        g.fillOval(circle.minX, circle.minX, circle.width,
+                circle.height)
+        g.stroke = s
+        g.strokeOval(circle.minX, circle.minX, circle.width,
+                circle.height)
+        g.rotate(MathUtils.atan2(axis.y, axis.x).toDouble())
+        g.strokeLine(0.0, 0.0, 1.0, 0.0)
+        restoreState(g)
+    }
+
+    private val zero = Vec2()
+    private val pcolorA = Color(1.0, 1.0, 1.0, .4)
+    override fun drawParticles(centers: Array<Vec2>, radius: Float,
+                               colors: Array<ParticleColor>?, count: Int) {
+        val g = graphics
+        saveState(g)
+        val scaling = transformGraphics(g, zero) * radius
+        g.lineWidth = stroke / scaling
+        for (i in 0 until count) {
+            val center = centers[i]
+            val color: Color = if (colors == null) {
+                pcolorA
+            } else {
+                val c = colors[i]
+                cpool.getColor(c.r * 1f / 127, c.g * 1f / 127,
+                        c.b * 1f / 127, c.a * 1f / 127)
+            }
+            val old = g.transform
+            g.translate(center.x.toDouble(), center.y.toDouble())
+            g.scale(radius.toDouble(), radius.toDouble())
+            g.fill = color
+            g.fillOval(circle.minX, circle.minX, circle.width,
+                    circle.height)
+            g.transform = old
+        }
+        restoreState(g)
+    }
+
+    private val pcolor = Color(1.0, 1.0, 1.0, 1.0)
+    override fun drawParticlesWireframe(centers: Array<Vec2>, radius: Float,
+                                        colors: Array<ParticleColor>?, count: Int) {
+        val g = graphics
+        saveState(g)
+        val scaling = transformGraphics(g, zero) * radius
+        g.lineWidth = stroke / scaling
+        for (i in 0 until count) {
+            val center = centers[i]
+            val color: Color
+            // No alpha channel, it slows everything down way too much.
+            color = if (colors == null) {
+                pcolor
+            } else {
+                val c = colors[i]
+                Color(c.r * 1f / 127.toDouble(), c.g * 1f / 127.toDouble(),
+                        c.b * 1f / 127.toDouble(), 1.0)
+            }
+            val old = g.transform
+            g.translate(center.x.toDouble(), center.y.toDouble())
+            g.scale(radius.toDouble(), radius.toDouble())
+            g.stroke = color
+            g.strokeOval(circle.minX, circle.minX, circle.width,
+                    circle.height)
+            g.transform = old
+        }
+        restoreState(g)
+    }
+
+    private val temp = Vec2()
+    override fun drawSolidPolygon(vertices: Array<Vec2>, vertexCount: Int,
+                                  color: Color3f) {
+        val f = cpool.getColor(color.x, color.y, color.z, .4f)
+        val s = cpool.getColor(color.x, color.y, color.z, 1f)
+        val g = graphics
+        saveState(g)
+        val xs = xDoublePool[vertexCount]
+        val ys = yDoublePool[vertexCount]
+        for (i in 0 until vertexCount) {
+            getWorldToScreenToOut(vertices[i], temp)
+            xs[i] = temp.x.toDouble()
+            ys[i] = temp.y.toDouble()
+        }
+        g.lineWidth = stroke
+        g.fill = f
+        g.fillPolygon(xs, ys, vertexCount)
+        g.stroke = s
+        g.strokePolygon(xs, ys, vertexCount)
+        restoreState(g)
+    }
+
+    override fun drawPolygon(vertices: Array<Vec2>, vertexCount: Int, color: Color3f) {
+        val s = cpool.getColor(color.x, color.y, color.z, 1f)
+        val g = graphics
+        saveState(g)
+        val xs = xDoublePool[vertexCount]
+        val ys = yDoublePool[vertexCount]
+        for (i in 0 until vertexCount) {
+            getWorldToScreenToOut(vertices[i], temp)
+            xs[i] = temp.x.toDouble()
+            ys[i] = temp.y.toDouble()
+        }
+        g.lineWidth = stroke
+        g.stroke = s
+        g.strokePolygon(xs, ys, vertexCount)
+        restoreState(g)
+    }
+
+    override fun drawString(x: Float, y: Float, s: String, color: Color3f) {
+        val g = graphics
+        val c = cpool.getColor(color.x, color.y, color.z)
+        g.fill = c
+        g.fillText(s, x.toDouble(), y.toDouble())
+    }
+
+    private val graphics: GraphicsContext
+        private get() = panel.dbGraphics
+    private val temp2 = Vec2()
+    override fun drawTransform(xf: Transform) {
+        val g = graphics
+        getWorldToScreenToOut(xf.p, temp)
+        temp2.setZero()
+        val axisScale = 0.4f
+        var c = cpool.getColor(1f, 0f, 0f)
+        g.stroke = c
+        temp2.x = xf.p.x + axisScale * xf.q.c
+        temp2.y = xf.p.y + axisScale * xf.q.s
+        getWorldToScreenToOut(temp2, temp2)
+        g.strokeLine(temp.x.toDouble(), temp.y.toDouble(), temp2.x.toDouble(), temp2.y.toDouble())
+        c = cpool.getColor(0f, 1f, 0f)
+        g.stroke = c
+        temp2.x = xf.p.x + -axisScale * xf.q.s
+        temp2.y = xf.p.y + axisScale * xf.q.c
+        getWorldToScreenToOut(temp2, temp2)
+        g.strokeLine(temp.x.toDouble(), temp.y.toDouble(), temp2.x.toDouble(), temp2.y.toDouble())
+    }
+
+    companion object {
+        var circlePoints = 13
+        const val edgeWidth = 0.02f
+        private val xDoublePool = DoubleArray()
+        private val yDoublePool = DoubleArray()
+    }
+
+    init {
+        stroke = 1.0
+        circle = Rectangle2D(-1.0, -1.0, 2.0, 2.0)
+    }
+}

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/testbed/javafx/DoubleArray.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/testbed/javafx/DoubleArray.kt
@@ -1,0 +1,19 @@
+package com.github.hereliesaz.kfizzix.testbed.javafx
+
+import java.util.HashMap
+
+class DoubleArray {
+    private val map: MutableMap<Int, DoubleArray> = HashMap()
+    operator fun get(argLength: Int): DoubleArray {
+        assert(argLength > 0)
+        if (!map.containsKey(argLength)) {
+            map[argLength] = getInitializedArray(argLength)
+        }
+        assert(map[argLength]!!.size == argLength) { "Array not built of correct length" }
+        return map[argLength]!!
+    }
+
+    protected fun getInitializedArray(argLength: Int): DoubleArray {
+        return DoubleArray(argLength)
+    }
+}

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/testbed/javafx/JavaFXPanelHelper.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/testbed/javafx/JavaFXPanelHelper.kt
@@ -1,0 +1,134 @@
+package com.github.hereliesaz.kfizzix.testbed.javafx
+
+import com.google.common.collect.Lists
+import com.github.hereliesaz.kfizzix.common.Vec2
+import com.github.hereliesaz.kfizzix.testbed.framework.AbstractTestbedController
+import com.github.hereliesaz.kfizzix.testbed.framework.TestbedCamera.ZoomType
+import com.github.hereliesaz.kfizzix.testbed.framework.TestbedModel
+import com.github.hereliesaz.kfizzix.testbed.framework.TestbedTest
+import javafx.scene.Node
+import javafx.scene.input.KeyCode
+import javafx.scene.input.MouseButton
+import javafx.scene.input.MouseEvent
+
+object JavaFXPanelHelper {
+    var screenDragButtonDown = false
+    var mouseJointButtonDown = false
+
+    /**
+     * Adds common help text and listeners for awt-based testbeds.
+     */
+    fun addHelpAndPanelListeners(panel: Node,
+                                 model: TestbedModel,
+                                 controller: AbstractTestbedController,
+                                 screenDragButton: Int) {
+        val oldDragMouse = Vec2()
+        val mouse = Vec2()
+        val help = Lists.newArrayList<String>()
+        help.add("Click and drag the left mouse button to move objects.")
+        help.add("Click and drag the right mouse button to move the view.")
+        help.add("Shift-Click to aim a bullet, or press space.")
+        help.add("Scroll to zoom in/out on the mouse position")
+        help.add("Press '[' or ']' to change tests, and 'r' to restart.")
+        model.setImplSpecificHelp(help)
+        panel.setOnZoom { zoomEvent ->
+            val currTest = model.currTest ?: return@setOnZoom
+            val zoom = if (zoomEvent.zoomFactor > 1) ZoomType.ZOOM_IN else ZoomType.ZOOM_OUT
+            currTest.camera.zoomToPoint(mouse, zoom)
+        }
+        panel.setOnScroll { scrollEvent ->
+            val currTest = model.currTest
+            if (currTest == null || scrollEvent.deltaY == 0.0) {
+                return@setOnScroll
+            }
+            val zoom = if (scrollEvent.deltaY > 1) ZoomType.ZOOM_IN else ZoomType.ZOOM_OUT
+            currTest.camera.zoomToPoint(mouse, zoom)
+        }
+        panel.setOnMouseReleased { mouseEvent ->
+            if (toInt(mouseEvent.button) == screenDragButton) {
+                screenDragButtonDown = false
+            } else if (model.codedKeys[toInt(KeyCode.SHIFT)]
+                    && !mouseJointButtonDown) {
+                controller.queueMouseUp(toVec(mouseEvent),
+                        TestbedTest.BOMB_SPAWN_BUTTON)
+            } else {
+                if (toInt(mouseEvent
+                                .button) == TestbedTest.MOUSE_JOINT_BUTTON) {
+                    mouseJointButtonDown = false
+                }
+                controller.queueMouseUp(
+                        Vec2(mouseEvent.x.toFloat(),
+                                mouseEvent.y.toFloat()),
+                        toInt(mouseEvent.button))
+            }
+        }
+        panel.setOnMousePressed { mouseEvent ->
+            if (toInt(mouseEvent.button) == screenDragButton) {
+                screenDragButtonDown = true
+                oldDragMouse.set(toVec(mouseEvent))
+                return@setOnMousePressed
+            } else if (model.codedKeys[toInt(KeyCode.SHIFT)]) {
+                controller.queueMouseDown(toVec(mouseEvent),
+                        TestbedTest.BOMB_SPAWN_BUTTON)
+            } else {
+                if (toInt(mouseEvent
+                                .button) == TestbedTest.MOUSE_JOINT_BUTTON) {
+                    mouseJointButtonDown = true
+                }
+                controller.queueMouseDown(toVec(mouseEvent),
+                        toInt(mouseEvent.button))
+            }
+        }
+        panel.setOnMouseMoved { mouseEvent ->
+            mouse.set(toVec(mouseEvent))
+            controller.queueMouseMove(toVec(mouseEvent))
+        }
+        panel.setOnMouseDragged { mouseEvent ->
+            mouse.set(toVec(mouseEvent))
+            if (screenDragButtonDown) {
+                val currTest = model.currTest ?: return@setOnMouseDragged
+                val diff = oldDragMouse.sub(mouse)
+                currTest.camera.moveWorld(diff)
+                oldDragMouse.set(mouse)
+            } else if (mouseJointButtonDown) {
+                controller.queueMouseDrag(Vec2(mouse),
+                        TestbedTest.MOUSE_JOINT_BUTTON)
+            } else if (model.codedKeys[toInt(KeyCode.SHIFT)]) {
+                controller.queueMouseDrag(toVec(mouseEvent),
+                        TestbedTest.BOMB_SPAWN_BUTTON)
+            } else {
+                controller.queueMouseDrag(toVec(mouseEvent),
+                        toInt(mouseEvent.button))
+            }
+        }
+        panel.setOnKeyReleased { keyEvent ->
+            val keyName = keyEvent.text
+            val c = if (keyName.length == 1) keyName[0] else '\u0000'
+            controller.queueKeyReleased(c, toInt(keyEvent.code))
+        }
+        panel.setOnKeyPressed { keyEvent ->
+            val keyName = keyEvent.text
+            val c = if (keyName.length == 1) keyName[0] else '\u0000'
+            controller.queueKeyPressed(c, toInt(keyEvent.code))
+            when (c) {
+                '[' -> controller.lastTest()
+                ']' -> controller.nextTest()
+                'r' -> controller.reset()
+                ' ' -> controller.queueLaunchBomb()
+                'p' -> controller.queuePause()
+            }
+        }
+    }
+
+    private fun toInt(key: KeyCode): Int {
+        return key.ordinal
+    }
+
+    private fun toInt(button: MouseButton): Int {
+        return button.ordinal
+    }
+
+    private fun toVec(mouseEvent: MouseEvent): Vec2 {
+        return Vec2(mouseEvent.x.toFloat(), mouseEvent.y.toFloat())
+    }
+}

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/testbed/javafx/TestPanelJavaFX.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/testbed/javafx/TestPanelJavaFX.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2013, Daniel Murphy All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met: * Redistributions of source code must retain the
+ * above copyright notice, this list of conditions and the following disclaimer. * Redistributions
+ * in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.github.hereliesaz.kfizzix.testbed.javafx
+
+import com.github.hereliesaz.kfizzix.testbed.framework.AbstractTestbedController
+import com.github.hereliesaz.kfizzix.testbed.framework.TestbedModel
+import com.github.hereliesaz.kfizzix.testbed.framework.TestbedPanel
+import javafx.application.Platform
+import javafx.beans.value.ChangeListener
+import javafx.scene.canvas.Canvas
+import javafx.scene.canvas.GraphicsContext
+import javafx.scene.input.MouseButton
+import javafx.scene.layout.BorderPane
+import javafx.scene.paint.Color
+import javafx.scene.text.Font
+import org.slf4j.LoggerFactory
+
+/**
+ * @author Daniel Murphy
+ */
+class TestPanelJavaFX : Canvas, TestbedPanel {
+    private val controller: AbstractTestbedController
+
+    constructor(model: TestbedModel,
+                controller: AbstractTestbedController, parent: BorderPane) : this(model, controller) {
+        // bind canvas size to parent
+        widthProperty().bind(parent.widthProperty().subtract(175))
+        heightProperty().bind(parent.heightProperty())
+    }
+
+    constructor(model: TestbedModel,
+                controller: AbstractTestbedController) : super(INIT_WIDTH.toDouble(), INIT_HEIGHT.toDouble()) {
+        this.controller = controller
+        updateSize(INIT_WIDTH.toDouble(), INIT_HEIGHT.toDouble())
+        JavaFXPanelHelper.addHelpAndPanelListeners(this, model, controller,
+                SCREEN_DRAG_BUTTON)
+        val sizeListener = ChangeListener<Number> { prop, oldValue, newValue -> updateSize(width, height) }
+        widthProperty().addListener(sizeListener)
+        heightProperty().addListener(sizeListener)
+        graphicsContext2D.font = Font("Courier New", 12.0)
+    }
+
+    override fun maxWidth(height: Double): Double {
+        return Double.MAX_VALUE
+    }
+
+    override fun maxHeight(width: Double): Double {
+        return Double.MAX_VALUE
+    }
+
+    val dbGraphics: GraphicsContext
+        get() = graphicsContext2D
+
+    private fun updateSize(width: Double, height: Double) {
+        controller.updateExtents(width.toFloat() / 2, height.toFloat() / 2)
+    }
+
+    fun render(): Boolean {
+        val dbg = dbGraphics
+        dbg.fill = Color.BLACK
+        val bounds = boundsInLocal
+        dbg.fillRect(bounds.minX, bounds.minX, bounds.width,
+                bounds.height)
+        return true
+    }
+
+    fun paintScreen() {}
+    override fun grabFocus() {
+        Platform.runLater { requestFocus() }
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(TestPanelJavaFX::class.java)
+        val SCREEN_DRAG_BUTTON = MouseButton.SECONDARY
+                .ordinal
+        const val INIT_WIDTH = 600
+        const val INIT_HEIGHT = 600
+    }
+}

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/testbed/javafx/TestbedControllerJavaFX.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/testbed/javafx/TestbedControllerJavaFX.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2013, Daniel Murphy All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met: * Redistributions of source code must retain the
+ * above copyright notice, this list of conditions and the following disclaimer. * Redistributions
+ * in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.github.hereliesaz.kfizzix.testbed.javafx
+
+import com.github.hereliesaz.kfizzix.testbed.framework.AbstractTestbedController
+import com.github.hereliesaz.kfizzix.testbed.framework.TestbedErrorHandler
+import com.github.hereliesaz.kfizzix.testbed.framework.TestbedModel
+import javafx.animation.AnimationTimer
+
+/**
+ * This class contains most control logic for the testbed and the update loop. It also watches the
+ * model to switch tests and populates the model with some loop statistics.
+ *
+ * @author Daniel Murphy
+ */
+class TestbedControllerJavaFX(argModel: TestbedModel,
+                              behavior: UpdateBehavior, mouseBehavior: MouseBehavior,
+                              errorHandler: TestbedErrorHandler) : AbstractTestbedController(argModel, behavior, mouseBehavior, errorHandler) {
+    private val animator: AnimationTimer = object : AnimationTimer() {
+        var last: Long = -1
+        override fun handle(now: Long) {
+            if (last >= 0) {
+                val dt = (now - last) / 1000000 // convert til millis
+                sleepTime -= dt
+                if (sleepTime < 0) {
+                    stepAndRender()
+                }
+            }
+            last = now
+        }
+    }
+
+    override fun startAnimator() {
+        animator.start()
+    }
+
+    override fun stopAnimator() {
+        animator.stop()
+    }
+}

--- a/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/testbed/javafx/TestbedSidePanel.kt
+++ b/kbox2d-library/src/main/kotlin/com/hereliesaz/kbox2d/testbed/javafx/TestbedSidePanel.kt
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2013, Daniel Murphy All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met: * Redistributions of source code must retain the
+ * above copyright notice, this list of conditions and the following disclaimer. * Redistributions
+ * in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.github.hereliesaz.kfizzix.testbed.javafx
+
+import com.github.hereliesaz.kfizzix.testbed.framework.*
+import com.github.hereliesaz.kfizzix.testbed.framework.TestbedModel.ListItem
+import com.github.hereliesaz.kfizzix.testbed.framework.TestbedSetting.SettingType
+import javafx.collections.ObservableList
+import javafx.geometry.Pos
+import javafx.scene.control.*
+import javafx.scene.layout.BorderPane
+import javafx.scene.layout.HBox
+import javafx.scene.layout.Pane
+import javafx.scene.layout.VBox
+import javax.swing.ComboBoxModel
+import javax.swing.DefaultComboBoxModel
+import javax.swing.event.ListDataEvent
+import javax.swing.event.ListDataListener
+
+/**
+ * The testbed side panel. Facilitates test and setting changes.
+ *
+ * @author Daniel Murphy
+ */
+class TestbedSidePanel(private val model: TestbedModel,
+                       private val controller: AbstractTestbedController) : BorderPane() {
+    lateinit var tests: ComboBox<ListItem>
+    private val pauseButton = Button("Pause")
+    private val stepButton = Button("Step")
+    private val resetButton = Button("Reset")
+    private val quitButton = Button("Quit")
+    var saveButton = Button("Save")
+    var loadButton = Button("Load")
+    private fun updateTests(model: ComboBoxModel<ListItem>) {
+        val list = tests.itemsProperty().get()
+        list.clear()
+        for (i in 0 until model.size) {
+            list.add(model.getElementAt(i) as ListItem)
+        }
+    }
+
+    fun initComponents() {
+        // setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
+        val settings = model.settings
+        val top = VBox()
+        // top.setLayout(new GridLayout(0, 1));
+// top.setBorder(BorderFactory.createCompoundBorder(new
+// EtchedBorder(EtchedBorder.LOWERED),
+// BorderFactory.createEmptyBorder(10, 10, 10, 10)));
+        val testList = model.comboModel as DefaultComboBoxModel<*>
+        testList.addListDataListener(object : ListDataListener {
+            override fun intervalRemoved(e: ListDataEvent) {
+                updateTests(e.source as ComboBoxModel<ListItem>)
+            }
+
+            override fun intervalAdded(e: ListDataEvent) {
+                updateTests(e.source as ComboBoxModel<ListItem>)
+            }
+
+            override fun contentsChanged(e: ListDataEvent) {
+                updateTests(e.source as ComboBoxModel<ListItem>)
+            }
+        })
+        tests = ComboBox()
+        updateTests(testList as ComboBoxModel<ListItem>)
+        tests.onAction = javafx.event.EventHandler { testSelected() }
+        tests.cellFactory = javafx.util.Callback { param: ListView<ListItem?>? ->
+            object : ListCell<ListItem?>() {
+                override fun updateItem(item: ListItem?, empty: Boolean) {
+                    super.updateItem(item, empty)
+                    if (item != null) {
+                        text = if (item.isCategory) item.category else item.test.testName
+                        isDisable = item.isCategory
+                    }
+                }
+            }
+        }
+        top.children.add(Label("Choose a test:"))
+        top.children.add(tests)
+        addSettings(top, settings, SettingType.DRAWING)
+        setTop(top)
+        val middle = VBox()
+        // middle.setLayout(new GridLayout(0, 1));
+// middle.setBorder(BorderFactory.createCompoundBorder(new
+// EtchedBorder(EtchedBorder.LOWERED),
+// BorderFactory.createEmptyBorder(5, 10, 5, 10)));
+        addSettings(middle, settings, SettingType.ENGINE)
+        center = middle
+        pauseButton.alignment = Pos.CENTER
+        stepButton.alignment = Pos.CENTER
+        resetButton.alignment = Pos.CENTER
+        saveButton.alignment = Pos.CENTER
+        loadButton.alignment = Pos.CENTER
+        quitButton.alignment = Pos.CENTER
+        val buttonGroups = HBox()
+        val buttons1 = VBox()
+        buttons1.children.add(resetButton)
+        val buttons2 = VBox()
+        buttons2.children.add(pauseButton)
+        buttons2.children.add(stepButton)
+        val buttons3 = VBox()
+        buttons3.children.add(saveButton)
+        buttons3.children.add(loadButton)
+        buttons3.children.add(quitButton)
+        buttonGroups.children.add(buttons1)
+        buttonGroups.children.add(buttons2)
+        buttonGroups.children.add(buttons3)
+        bottom = buttonGroups
+    }
+
+    protected fun testSelected() {
+        val testNum = tests.selectionModel.selectedIndex
+        controller.playTest(testNum)
+    }
+
+    fun addListeners() {
+        pauseButton.onAction = javafx.event.EventHandler { e ->
+            if (model.settings.pause) {
+                model.settings.pause = false
+                pauseButton.text = "Pause"
+            } else {
+                model.settings.pause = true
+                pauseButton.text = "Resume"
+            }
+            model.panel.grabFocus()
+        }
+        stepButton.onAction = javafx.event.EventHandler { e ->
+            model.settings.singleStep = true
+            if (!model.settings.pause) {
+                model.settings.pause = true
+                pauseButton.text = "Resume"
+            }
+            model.panel.grabFocus()
+        }
+        resetButton.onAction = javafx.event.EventHandler { e -> controller.reset() }
+        quitButton.onAction = javafx.event.EventHandler { e -> System.exit(0) }
+        saveButton.onAction = javafx.event.EventHandler { e -> controller.save() }
+        loadButton.onAction = javafx.event.EventHandler { e -> controller.load() }
+    }
+
+    private fun addSettings(argPanel: Pane, argSettings: TestbedSettings,
+                            argIgnore: SettingType) {
+        for (setting in argSettings.settings) {
+            if (setting.settingsType == argIgnore) {
+                continue
+            }
+            when (setting.constraintType) {
+                TestbedSetting.ConstraintType.RANGE -> {
+                    val text = Label(setting.name + ": " + setting.value)
+                    val slider = Slider(setting.min.toDouble(), setting.max.toDouble(),
+                            setting.value.toDouble())
+                    // slider.setMaximumSize(new Dimension(200, 20));
+                    slider.valueProperty()
+                            .addListener { prop, oldValue, newValue -> stateChanged(slider) }
+                    putClientProperty(slider, "name", setting.name)
+                    putClientProperty(slider, SETTING_TAG, setting)
+                    putClientProperty(slider, LABEL_TAG, text)
+                    argPanel.children.add(text)
+                    argPanel.children.add(slider)
+                }
+                TestbedSetting.ConstraintType.BOOLEAN -> {
+                    val checkbox = CheckBox(setting.name)
+                    checkbox.isSelected = setting.enabled
+                    checkbox.selectedProperty()
+                            .addListener { prop, oldValue, newValue -> stateChanged(checkbox) }
+                    putClientProperty(checkbox, SETTING_TAG, setting)
+                    argPanel.children.add(checkbox)
+                }
+            }
+        }
+    }
+
+    private fun <T> getClientProperty(control: Control, tag: String): T? {
+        val map = control.userData as Map<String, Any>?
+        return if (map != null) map[tag] as T? else null
+    }
+
+    private fun putClientProperty(control: Control, tag: String, o: Any) {
+        var map = control.userData as MutableMap<String, Any>?
+        if (map == null) {
+            map = HashMap()
+            control.userData = map
+        }
+        map[tag] = o
+    }
+
+    fun stateChanged(control: Control) {
+        val setting = getClientProperty<TestbedSetting>(control, SETTING_TAG)!!
+        when (setting.constraintType) {
+            TestbedSetting.ConstraintType.BOOLEAN -> {
+                val box = control as CheckBox
+                setting.enabled = box.isSelected
+            }
+            TestbedSetting.ConstraintType.RANGE -> {
+                val slider = control as Slider
+                setting.value = slider.value.toInt()
+                val label = getClientProperty<Label>(slider, LABEL_TAG)!!
+                label.text = setting.name + ": " + setting.value
+            }
+        }
+        model.panel.grabFocus()
+    }
+
+    companion object {
+        private const val SETTING_TAG = "settings"
+        private const val LABEL_TAG = "label"
+    }
+
+    init {
+        model.addTestChangeListener { argTest, argIndex ->
+            tests.selectionModel.select(argIndex)
+            saveButton.isDisable = !argTest.isSaveLoadEnabled
+            loadButton.isDisable = !argTest.isSaveLoadEnabled
+        }
+    }
+}

--- a/kbox2d-serialization-kt/build.gradle.kts
+++ b/kbox2d-serialization-kt/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
     implementation(kotlin("stdlib"))
     implementation("com.google.protobuf:protobuf-java:3.25.4")
     implementation("com.google.protobuf:protobuf-kotlin:3.25.4")
-    implementation(project(":kbox2d-library"))
+    implementation(project(":kfizzix-library"))
 }
 
 protobuf {

--- a/kbox2d-testbed-javafx-kt/build.gradle.kts
+++ b/kbox2d-testbed-javafx-kt/build.gradle.kts
@@ -11,7 +11,7 @@ repositories {
 
 dependencies {
     implementation(kotlin("stdlib"))
-    implementation(project(":kbox2d-library"))
+    implementation(project(":kfizzix-library"))
     implementation(project(":kbox2d-serialization-kt"))
     implementation("org.apache.commons:commons-math3:3.6.1")
     implementation("org.openjfx:javafx-controls:17.0.2")

--- a/kbox2d-testbed-javafx/build.gradle.kts
+++ b/kbox2d-testbed-javafx/build.gradle.kts
@@ -12,7 +12,7 @@ javafx {
 
 dependencies {
     implementation("org.apache.commons:commons-math3:3.6.1")
-    implementation(project(":kbox2d-library"))
+    implementation(project(":kfizzix-library"))
     implementation(project(":kbox2d-serialization-kt"))
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,12 +16,14 @@ pluginManagement {
     }
 }
 
-rootProject.name = "kbox2d"
+rootProject.name = "KFizzix"
 
 include(
-    ":kbox2d-library",
+    ":kfizzix-library",
     ":kbox2d-serialization-kt",
     ":kbox2d-testbed-javafx",
     ":kbox2d-testbed-javafx-kt",
     ":jbox2d-testbed-jogl"
 )
+
+project(":kfizzix-library").projectDir = file("kbox2d-library")


### PR DESCRIPTION
…he kbox2d library to create the unified KFizzix library.

The following changes have been made:
- The source code from the KPhysics library has been copied into the kbox2d-library module.
- The Gradle root project has been renamed to "KFizzix".
- The core library module has been renamed to ":kfizzix-library" in the Gradle settings.
- All project dependencies have been updated to point to the new ":kfizzix-library" module.
- All package names in the Kotlin source files have been refactored from "com.hereliesaz.jbox2d" and "com.hereliesaz.kbox2d" to "com.github.hereliesaz.kfizzix".

The directory structure has not yet been updated to match the new package names due to environment limitations. A script has been provided to the user to complete this step.

## Summary by Sourcery

Merge the KPhysics library into the existing kbox2d module and rebrand the combined codebase as KFizzix

New Features:
- Merge KPhysics code into kbox2d-library to create the unified KFizzix core
- Introduce Protobuf-based world serialization and deserialization (JbSerializer/JbDeserializer and PbSerializer/PbDeserializer)
- Add JavaFX-based testbed modules including DebugDrawJavaFX, TestPanelJavaFX, side panels, and controllers for interactive simulation

Enhancements:
- Rename root Gradle project to "KFizzix" and core module to ":kfizzix-library"
- Refactor all package names from com.hereliesaz.jbox2d/com.hereliesaz.kbox2d to com.github.hereliesaz.kfizzix
- Update build scripts and submodule Gradle files to reference the new ":kfizzix-library" module

Build:
- Update settings.gradle.kts to rename projects and adjust projectDir for kfizzix-library
- Update dependencies in submodule build files to point to ":kfizzix-library" instead of ":kbox2d-library"

Chores:
- Copy source code from KPhysics into kbox2d-library
- Add .gitignore and scaffolding for directory restructuring script